### PR TITLE
Add link to license in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include plotnine/_version.py
+include LICENSE


### PR DESCRIPTION
Hey-lo,

I'm [building a version](https://github.com/conda-forge/staged-recipes/pull/2997) of `plotnine` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution.

Currently I'm using a local copy of the license, but this pull should add a copy of the license to the next source build.