### PR TITLE
Fix stat_density when xlim is used

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,12 +14,15 @@ v0.2.1
 
 - Fixed bug in :class:`~plotnine.stat_summary` where the you got
   an exception for some types of the `x` aesthetic values.
-  
+
 - Fixed bug where ``ggplot(data=df)`` resulted in an exception.
 
 - Fixed missing axis ticks and labels for :class:`~plotnine.facet_wrap`
   when the scales are allowed to vary (e.g `scales='free'`) between
   the panels.
+
+- Fixed bug in :class:`~plotnine.stat_density` where changing the
+  x limits lead to an exception (:issue: `22`)
 
 
 v0.2.0

--- a/plotnine/stats/stat_density.py
+++ b/plotnine/stats/stat_density.py
@@ -132,6 +132,10 @@ class stat_density(stat):
 
 
 def compute_density(x, weight, range, **params):
+    x = np.asarray(x, dtype=np.float)
+    not_nan = ~np.isnan(x)
+    x = x[not_nan]
+
     n = len(x)
 
     if weight is None:
@@ -156,7 +160,6 @@ def compute_density(x, weight, range, **params):
     else:
         fft = False
 
-    x = np.asarray(x, dtype=np.float)
     kde = sm.nonparametric.KDEUnivariate(x)
     kde.fit(
         kernel=params['kernel'],
@@ -190,8 +193,6 @@ def compute_density(x, weight, range, **params):
     not_nan = ~np.isnan(y)
     x2 = x2[not_nan]
     y = y[not_nan]
-
-    # print(np.sum(np.isnan(y)))
     return pd.DataFrame({'x': x2,
                          'density': y,
                          'scaled': y / np.max(y),

--- a/plotnine/tests/test_stat_calculate_methods.py
+++ b/plotnine/tests/test_stat_calculate_methods.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import six
 import pandas as pd
+import numpy as np
 import pytest
 
-from plotnine import ggplot, aes, stat_bin
+from plotnine import ggplot, aes, stat_bin, stat_density, xlim
 from plotnine.exceptions import PlotnineError
 
 
@@ -29,3 +30,15 @@ def test_stat_bin():
     gg = ggplot(aes(x='x', y='y'), df) + stat_bin()
     with pytest.raises(PlotnineError):
         gg.draw_test()
+
+
+def test_changing_xlim_in_stat_density():
+    n = 100
+    _xlim = (5, 10)
+    df = pd.DataFrame({'x': np.linspace(_xlim[0]-1, _xlim[1]+1, n)})
+    p = (ggplot(df, aes('x'))
+         + stat_density()
+         + xlim(*_xlim)
+         )
+    # No exceptions
+    p._build()


### PR DESCRIPTION
Introduced `nan`s for values outside the limits messed with
the density computations. Solution is to remove the `nan`s
before computing the density.

fixes #22