### PR TITLE
Fix coord_cartesian y-axis scaling

### DIFF
--- a/plotnine/coords/coord_cartesian.py
+++ b/plotnine/coords/coord_cartesian.py
@@ -65,7 +65,7 @@ class coord_cartesian(coord):
 
         # When Python 2.7 end of life, change this to dict(**a, **b)
         out = train(scale_x, self.limits.xlim, 'x')
-        out.update(train(scale_y, self.limits.xlim, 'y'))
+        out.update(train(scale_y, self.limits.ylim, 'y'))
         return out
 
     @staticmethod


### PR DESCRIPTION
This corrects a bug where y-axis scaling was calculated from the `xlim` argument.