### PR TITLE
Fix using classes in stat and geom creation.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,10 @@ v0.3.0
 
 - Fix bug where y-axis scaling was calculated from the ``xlim`` argument.
 
+- Fix bug where initialising geoms from stats, and positions from geoms,
+  when passed as classes (e.g. ``stat_smooth(geom=geom_point)``, would
+  fail.
+
 API Changes
 ***********
 

--- a/plotnine/geoms/geom.py
+++ b/plotnine/geoms/geom.py
@@ -65,7 +65,7 @@ class geom(object):
         if issubclass(type(name), geom):
             return name
 
-        if isinstance(name, geom):
+        if isinstance(name, type) and issubclass(name, geom):
             klass = name
         elif is_string(name):
             if not name.startswith('geom_'):

--- a/plotnine/positions/position.py
+++ b/plotnine/positions/position.py
@@ -125,7 +125,7 @@ class position(object):
         if issubclass(type(name), position):
             return name
 
-        if isinstance(name, position):
+        if isinstance(name, type) and issubclass(name, position):
             klass = name
         elif is_string(name):
             if not name.startswith('position_'):

--- a/plotnine/tests/test_geom.py
+++ b/plotnine/tests/test_geom.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import pandas as pd
 import pytest
 
+import plotnine as p9
 from plotnine import ggplot, aes
 from plotnine.geoms.geom import geom
 from plotnine.exceptions import PlotnineError
@@ -53,3 +54,16 @@ def test_geom_with_invalid_argument():
 
     with pytest.raises(PlotnineError):
         geom_abc(do_the_impossible=True)
+
+def test_geom_from_stat():
+    stat = p9.stat_identity(geom='point')
+    assert isinstance(geom.from_stat(stat), p9.geom_point)
+
+    stat = p9.stat_identity(geom='geom_point')
+    assert isinstance(geom.from_stat(stat), p9.geom_point)
+
+    stat = p9.stat_identity(geom=p9.geom_point())
+    assert isinstance(geom.from_stat(stat), p9.geom_point)
+
+    stat = p9.stat_identity(geom=p9.geom_point)
+    assert isinstance(geom.from_stat(stat), p9.geom_point)

--- a/plotnine/tests/test_geom.py
+++ b/plotnine/tests/test_geom.py
@@ -4,8 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import pandas as pd
 import pytest
 
-import plotnine as p9
-from plotnine import ggplot, aes
+from plotnine import ggplot, aes, stat_identity, geom_point
 from plotnine.geoms.geom import geom
 from plotnine.exceptions import PlotnineError
 
@@ -55,15 +54,16 @@ def test_geom_with_invalid_argument():
     with pytest.raises(PlotnineError):
         geom_abc(do_the_impossible=True)
 
+
 def test_geom_from_stat():
-    stat = p9.stat_identity(geom='point')
-    assert isinstance(geom.from_stat(stat), p9.geom_point)
+    stat = stat_identity(geom='point')
+    assert isinstance(geom.from_stat(stat), geom_point)
 
-    stat = p9.stat_identity(geom='geom_point')
-    assert isinstance(geom.from_stat(stat), p9.geom_point)
+    stat = stat_identity(geom='geom_point')
+    assert isinstance(geom.from_stat(stat), geom_point)
 
-    stat = p9.stat_identity(geom=p9.geom_point())
-    assert isinstance(geom.from_stat(stat), p9.geom_point)
+    stat = stat_identity(geom=geom_point())
+    assert isinstance(geom.from_stat(stat), geom_point)
 
-    stat = p9.stat_identity(geom=p9.geom_point)
-    assert isinstance(geom.from_stat(stat), p9.geom_point)
+    stat = stat_identity(geom=geom_point)
+    assert isinstance(geom.from_stat(stat), geom_point)

--- a/plotnine/tests/test_position.py
+++ b/plotnine/tests/test_position.py
@@ -9,6 +9,7 @@ from plotnine import (ggplot, aes, geom_point, geom_jitter, geom_bar,
                       geom_col, geom_text, position_dodge,
                       position_jitter, position_jitterdodge,
                       position_nudge, position_stack, theme)
+from plotnine.positions.position import position
 from plotnine.exceptions import PlotnineError
 
 n = 6
@@ -94,3 +95,16 @@ def test_jitterdodge():
          geom_point(size=10, fill='black') +
          geom_point(size=10, position=position))
     assert p + _theme == 'jitterdodge'
+
+def test_position_from_geom():
+    geom = geom_point(position='jitter')
+    assert isinstance(position.from_geom(geom), position_jitter)
+
+    geom = geom_point(position='position_jitter')
+    assert isinstance(position.from_geom(geom), position_jitter)
+
+    geom = geom_point(position=position_jitter())
+    assert isinstance(position.from_geom(geom), position_jitter)
+
+    geom = geom_point(position=position_jitter)
+    assert isinstance(position.from_geom(geom), position_jitter)

--- a/plotnine/tests/test_position.py
+++ b/plotnine/tests/test_position.py
@@ -96,6 +96,7 @@ def test_jitterdodge():
          geom_point(size=10, position=position))
     assert p + _theme == 'jitterdodge'
 
+
 def test_position_from_geom():
     geom = geom_point(position='jitter')
     assert isinstance(position.from_geom(geom), position_jitter)


### PR DESCRIPTION
Speifically, things like `stat_identity(geom=geom_point)` and
`geom_point(position=position_jitter)` now work.
`geom_point(stat=stat_identity)` already worked (624a5cda).