### PR TITLE
[sketch] Fix scale_color_cmap to work on discrete cmaps

### DIFF
--- a/plotnine/scales/scale_color.py
+++ b/plotnine/scales/scale_color.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from warnings import warn
 
+import matplotlib as mpl
 from mizani.bounds import rescale_mid
 from mizani.palettes import (hue_pal, brewer_pal, grey_pal,
                              gradient_n_pal, cmap_pal,
@@ -370,8 +371,22 @@ class scale_fill_distiller(scale_color_distiller):
 
 
 # matplotlib colormaps
+def scale_color_cmap(cmap, *args, **kwargs):
+    if isinstance(cmap, mpl.colors.ListedColormap):
+        return scale_color_manual([mpl.colors.to_hex(x) for x in cmap.colors], *args, **kwargs)
+    else:
+        return _scale_color_cmap(cmap, *args, **kwargs)
+
+
+def scale_fill_cmap(cmap, *args, **kwargs):
+    if isinstance(cmap, mpl.colors.ListedColormap):
+        return scale_fill_manual([mpl.colors.to_hex(x) for x in cmap.colors], *args, **kwargs)
+    else:
+        return _scale_fill_cmap(cmap, *args, **kwargs)
+
+
 @document
-class scale_color_cmap(scale_continuous):
+class _scale_color_cmap(scale_continuous):
     """
     Create color scales using Matplotlib colormaps
 
@@ -405,7 +420,7 @@ class scale_color_cmap(scale_continuous):
 
 
 @document
-class scale_fill_cmap(scale_color_cmap):
+class _scale_fill_cmap(scale_color_cmap):
     """
     Create color scales using Matplotlib colormaps
 


### PR DESCRIPTION
- `scale_color_cmap`/`scale_fill_cmap` currently only work on continuous cmaps, which makes them fail when naively combined with discrete values
- Fixing this seems to only require switching on whether the input `cmap` is discrete or continuous and delegating to `scale_*_manual` in the discrete case, but I'm not sure how you want to handle stuff like code org, docstrings, `@document`, and tests so I made this quick PR as a sketch
- Does this look like the right approach? What more should I do to make it able to merge?