### PR TITLE
Removed erroneous extra parenthesis in example code.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ Example
 .. code:: python
 
     (ggplot(mtcars, aes('wt', 'mpg', color='factor(gear)'))
-     + geom_point())
+     + geom_point()
      + stat_smooth(method='lm')
      + facet_wrap('~gear'))
 


### PR DESCRIPTION
The example code fails with syntax error. Removed erroneous extra parenthesis.