### PR TITLE
Fix failing formula without dot in facet_grid

### DIFF
--- a/plotnine/facets/facet_grid.py
+++ b/plotnine/facets/facet_grid.py
@@ -335,6 +335,7 @@ def parse_grid_facets(facets):
 
     return rows, cols
 
+
 def ensure_var_or_dot(formula_term):
     """
     Ensure that a non specified formula term is transformed into a dot.

--- a/plotnine/facets/facet_grid.py
+++ b/plotnine/facets/facet_grid.py
@@ -317,6 +317,9 @@ def parse_grid_facets(facets):
         lhs = lhs.strip()
         rhs = rhs.strip()
 
+    lhs = ensure_var_or_dot(lhs)
+    rhs = ensure_var_or_dot(rhs)
+
     lsplitter = ' + ' if ' + ' in lhs else '+'
     rsplitter = ' + ' if ' + ' in rhs else '+'
 
@@ -331,3 +334,9 @@ def parse_grid_facets(facets):
         cols = [var.strip() for var in rhs.split(rsplitter)]
 
     return rows, cols
+
+def ensure_var_or_dot(formula_term):
+    """
+    Ensure that a non specified formula term is transformed into a dot.
+    """
+    return formula_term if formula_term else '.'

--- a/plotnine/tests/test_facets.py
+++ b/plotnine/tests/test_facets.py
@@ -91,11 +91,12 @@ def test_facet_grid_scales_free_y():
          + theme(panel_spacing_x=0.3))
     assert p == 'facet_grid_scales_free_y'
 
+
 def test_facet_grid_scales_free_y_formula_dot_notation():
-    p = (g
-         + facet_grid('. ~ var1>2', scales='free_y')
+    p = (g+facet_grid('. ~ var1>2', scales='free_y')
          + theme(panel_spacing_x=0.3))
     assert p == 'facet_grid_scales_free_y'
+
 
 def test_facet_grid_scales_free_y_formula_no_dot():
     p = (g
@@ -103,10 +104,10 @@ def test_facet_grid_scales_free_y_formula_no_dot():
          + theme(panel_spacing_x=0.3))
     assert p == 'facet_grid_scales_free_y'
 
+
 def test_facet_grid_scales_free_x():
     p = (g
          + facet_grid(['var1>2', '.'], scales='free_x')
-
          + theme(panel_spacing_y=0.3))
     assert p == 'facet_grid_scales_free_x'
 

--- a/plotnine/tests/test_facets.py
+++ b/plotnine/tests/test_facets.py
@@ -91,6 +91,17 @@ def test_facet_grid_scales_free_y():
          + theme(panel_spacing_x=0.3))
     assert p == 'facet_grid_scales_free_y'
 
+def test_facet_grid_scales_free_y_formula_dot_notation():
+    p = (g
+         + facet_grid('. ~ var1>2', scales='free_y')
+         + theme(panel_spacing_x=0.3))
+    assert p == 'facet_grid_scales_free_y'
+
+def test_facet_grid_scales_free_y_formula_no_dot():
+    p = (g
+         + facet_grid('~var1>2', scales='free_y')
+         + theme(panel_spacing_x=0.3))
+    assert p == 'facet_grid_scales_free_y'
 
 def test_facet_grid_scales_free_x():
     p = (g

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,6 +5,7 @@ matplotlib
 mizani
 geopandas
 descartes
+scikit-misc
 
 # Documentation
 -r doc.txt


### PR DESCRIPTION
The facet_grid was failing if a dot was not specified for single
row/colum formulas. See test case
test_facet_grid_scales_free_y_formula_no_dot. It was failing with a
cryptic error, because somewhere down the line some code was
interpredeted as an imcomplete string. This is in contrast to R's
ggplot2, wich just seems to ignore missing dots. A dot is now just added
silently if missing. Alternative an exception could be thrown, but I
think this is more userfriendly. At least it should not fail with a
cryptic error as before. Moreover, scikit-misc is added as a dev 
dependency so that the smoothing tests do not fail locally.