### PR TITLE
utils.match: Speed up by ~45% by replacing `suppress(KeyError)` with `in`

### DIFF
--- a/plotnine/utils.py
+++ b/plotnine/utils.py
@@ -136,7 +136,7 @@ def match(v1, v2, nomatch=-1, incomparables=None, start=0):
         if x in skip:
             continue
 
-        with suppress(KeyError):
+        if x in lookup:
             lst[i] = lookup[x] + start
 
     return lst


### PR DESCRIPTION
Using a df with ~400K rows:
```py
>>> len(df)
399859
```

A simple `geom_bar` takes 3.1s:
```py
>>> %%prun -l10
... repr(df
...     .pipe(ggplot, aes(x='quality'))
...     + geom_bar()
... )
         3912976 function calls (3907115 primitive calls) in 3.050 seconds

   Ordered by: internal time
   List reduced from 2489 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        7    1.210    0.173    1.617    0.231 utils.py:104(match)
        5    0.293    0.059    0.293    0.059 {pandas._libs.lib.maybe_convert_objects}
        2    0.270    0.135    0.270    0.135 {built-in method matplotlib._png.write_png}
  1199783    0.185    0.000    0.185    0.000 contextlib.py:239(__init__)
  1199783    0.111    0.000    0.111    0.000 contextlib.py:245(__exit__)
      527    0.111    0.000    0.111    0.000 {method 'copy' of 'numpy.ndarray' objects}
4779/4704    0.110    0.000    0.120    0.000 {built-in method numpy.core.multiarray.array}
  1199783    0.096    0.000    0.096    0.000 contextlib.py:242(__enter__)
        1    0.091    0.091    0.190    0.190 layer.py:81(compute_aesthetics)
        1    0.059    0.059    0.059    0.059 missing.py:27(mask_missing) 
```

Doing the `groupby` manually reduces it to .72s:
```py
>>> %%prun -l10
... repr(df
...     .assign(n=1).groupby(['quality'])['n'].count().reset_index()
...     .pipe(ggplot, aes(x='quality', y='n'))
...     + geom_bar(stat='identity')
... )
         230436 function calls (225887 primitive calls) in 0.718 seconds

   Ordered by: internal time
   List reduced from 2382 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    0.264    0.132    0.264    0.132 {built-in method matplotlib._png.write_png}
      460    0.138    0.000    0.138    0.000 {method 'copy' of 'numpy.ndarray' objects}
        1    0.096    0.096    0.718    0.718 <string>:2(<module>)
    30741    0.008    0.000    0.014    0.000 {built-in method builtins.isinstance}
3874/3824    0.007    0.000    0.008    0.000 {built-in method numpy.core.multiarray.array}
     1205    0.005    0.000    0.005    0.000 {method 'reduce' of 'numpy.ufunc' objects}
       72    0.004    0.000    0.004    0.000 {method 'set_text' of 'matplotlib.ft2font.FT2Font' objects}
    10021    0.004    0.000    0.005    0.000 {built-in method builtins.getattr}
5352/4615    0.003    0.000    0.004    0.000 artist.py:230(stale)
       56    0.003    0.000    0.003    0.000 {method 'draw_path' of 'matplotlib.backends._backend_agg.RendererAgg' objects} 
```

Replacing `with suppress(KeyError)` with `x in lookup` speeds up the 3.1s to 1.7s:
```py
>>> %%prun -l10
... repr(df
...     .pipe(ggplot, aes(x='quality'))
...     + geom_bar()
... )
         314177 function calls (308316 primitive calls) in 1.658 seconds

   Ordered by: internal time
   List reduced from 2489 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        5    0.289    0.058    0.289    0.058 {pandas._libs.lib.maybe_convert_objects}
        2    0.270    0.135    0.270    0.135 {built-in method matplotlib._png.write_png}
        7    0.187    0.027    0.203    0.029 utils.py:104(match)
4780/4705    0.113    0.000    0.121    0.000 {built-in method numpy.core.multiarray.array}
      527    0.111    0.000    0.111    0.000 {method 'copy' of 'numpy.ndarray' objects}
        1    0.090    0.090    0.194    0.194 layer.py:81(compute_aesthetics)
        1    0.057    0.057    0.057    0.057 missing.py:27(mask_missing)
        5    0.031    0.006    0.104    0.021 scale_xy.py:65(map)
       65    0.018    0.000    0.018    0.000 {method 'tolist' of 'numpy.ndarray' objects}
      215    0.015    0.000    0.015    0.000 {method 'astype' of 'numpy.ndarray' objects} 
```