### PR TITLE
Add `save_as_pdf_pages`

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -21,6 +21,7 @@ Plot creation
    ~watermark.watermark
    ~layer.layer
    ~animation.PlotnineAnimation
+   ~ggplot.save_as_pdf_pages
 
 geoms
 =====

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -36,6 +36,8 @@ New Features
 
 - Added :class:`~plotnine.stats.stat_hull`.
 
+- Added :meth:`~plotnine.ggplot.save_as_pdf_pages`.
+
 Bug Fixes
 *********
 

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import os

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -741,11 +741,11 @@ def ggsave(plot, *arg, **kwargs):
 
 def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
     """
-    Save a collection of ggplot to a PDF file, one per page.
+    Save multiple :class:`ggplot` objects to a PDF file, one per page.
 
     Parameters
     ----------
-    plots : iterable of ggplot
+    plots : collection or generator of :class:`ggplot`
         Plot objects to write to file.
     filename : str, optional
         File name to write the plot to. If not specified, a name
@@ -757,6 +757,41 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
         If ``True``, print the saving information.
     kwargs : dict
         Additional arguments to pass to matplotlib `savefig()`.
+
+    `plots` may be either a collection such as a :python:class:`list`
+    or :python:class:`set`:
+
+    >>> base_plot = ggplot(…)
+    >>> plots = [base_plot + ggtitle('%d of 3' % i) for i in range(3)]
+    >>> save_as_pdf_pages(plots)
+
+    …or a generator that yields :class:`ggplot` objects:
+
+    >>> def myplots():
+    >>>     for i in range(3):
+    >>>         yield ggplot(…) + ggtitle('%d of 3' % i)
+    >>> save_as_pdf_pages(myplots())
+
+    Using pandas' groupby methods, plots can be “faceted” across pages:
+
+    >>> from plotnine.data import mtcars
+    >>> def facet_pages(column)
+    >>>     base_plot = [
+    >>>         aes(x='wt', y='mpg', label='name'),
+    >>>         geom_text(),
+    >>>         ]
+    >>>     for label, group_data in mtcars.groupby(column):
+    >>>         yield ggplot(group_data) + base_plot + ggtitle(label)
+    >>> save_as_pdf_pages(facet_pages('cyl'))
+
+    Unlike :meth:`ggplot.save`, :meth:`save_as_pdf_pages` does not
+    process arguments for `height` or `width`. To set the figure size,
+    add :class:`theme` to each individual :class:`ggplot` in `plots`:
+
+    >>> plot = ggplot(…)
+    >>> # The following are equivalent
+    >>> plot.save('filename.pdf', height=6, width=8)
+    >>> save_as_pdf_pages([plot + theme(figure_size=(8, 6))])
     """
     from itertools import chain
 

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -625,7 +625,7 @@ class ggplot(object):
         ----------
         filename : str, optional
             File name to write the plot to. If not specified, a name
-            like `plotnine-save-<hash>.ext` is used.
+            like “plotnine-save-<hash>.<format>” is used.
         format : str
             Image format to use, automatically extract from
             file name extension.
@@ -746,33 +746,36 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
     Parameters
     ----------
     plots : collection or generator of :class:`ggplot`
-        Plot objects to write to file.
-    filename : str, optional
+        Plot objects to write to file. `plots` may be either a
+        collection such as a :py:class:`list` or :py:class:`set`:
+
+        >>> base_plot = ggplot(…)
+        >>> plots = [base_plot + ggtitle('%d of 3' % i) for i in range(1, 3)]
+        >>> save_as_pdf_pages(plots)
+
+        or, a generator that yields :class:`ggplot` objects:
+
+        >>> def myplots():
+        >>>     for i in range(1, 3):
+        >>>         yield ggplot(…) + ggtitle('%d of 3' % i)
+        >>> save_as_pdf_pages(myplots())
+
+    filename : :py:class:`str`, optional
         File name to write the plot to. If not specified, a name
-        like `plotnine-save-<hash>.pdf` is used.
-    path : str, optional
+        like “plotnine-save-<hash>.pdf” is used.
+    path : :py:class:`str`, optional
         Path to save plot to (if you just want to set path and
         not filename).
-    verbose : bool
+    verbose : :py:class:`bool`
         If ``True``, print the saving information.
-    kwargs : dict
-        Additional arguments to pass to matplotlib `savefig()`.
+    kwargs : :py:class:`dict`
+        Additional arguments to pass to
+        :py:meth:`matplotlib.figure.Figure.savefig`.
 
-    `plots` may be either a collection such as a :python:class:`list`
-    or :python:class:`set`:
-
-    >>> base_plot = ggplot(…)
-    >>> plots = [base_plot + ggtitle('%d of 3' % i) for i in range(3)]
-    >>> save_as_pdf_pages(plots)
-
-    …or a generator that yields :class:`ggplot` objects:
-
-    >>> def myplots():
-    >>>     for i in range(3):
-    >>>         yield ggplot(…) + ggtitle('%d of 3' % i)
-    >>> save_as_pdf_pages(myplots())
-
-    Using pandas' groupby methods, plots can be “faceted” across pages:
+    Notes
+    -----
+    Using pandas' :meth:`~pandas.DataFrame.groupby` methods, tidy data
+    can be “faceted” across pages:
 
     >>> from plotnine.data import mtcars
     >>> def facet_pages(column)
@@ -786,7 +789,8 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
 
     Unlike :meth:`ggplot.save`, :meth:`save_as_pdf_pages` does not
     process arguments for `height` or `width`. To set the figure size,
-    add :class:`theme` to each individual :class:`ggplot` in `plots`:
+    add :class:`~plotnine.themes.themeable.figure_size` to the theme
+    for some or all of the objects in `plots`:
 
     >>> plot = ggplot(…)
     >>> # The following are equivalent

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -759,7 +759,9 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
         Additional arguments to pass to matplotlib `savefig()`.
     """
     from itertools import chain
+
     from matplotlib.backends.backend_pdf import PdfPages
+    from six import raise_from
 
     # as in ggplot.save()
     fig_kwargs = {'bbox_inches': 'tight'}
@@ -803,8 +805,8 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
                 # Save as a page in the PDF file
                 pdf.savefig(figure[0], **fig_kwargs)
             except AttributeError as err:
-                raise TypeError('non-ggplot object of %s: %s' %
-                                (type(plot), plot)) from err
+                raise_from(TypeError('non-ggplot object of %s: %s' %
+                           (type(plot), plot)), err)
             except Exception as err:
                 raise
             finally:

--- a/plotnine/tests/test_save_as_pdf_pages.py
+++ b/plotnine/tests/test_save_as_pdf_pages.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import pytest
 import six
 
-from plotnine import ggplot, aes, geom_text, ggtitle
+from plotnine import ggplot, aes, geom_text, ggtitle, theme
 from plotnine.data import mtcars
 from plotnine.ggplot import save_as_pdf_pages
 from plotnine.exceptions import PlotnineError
@@ -77,6 +77,16 @@ class TestArguments(object):
         fn = next(filename_gen)
         save_as_pdf_pages(p(), fn, path='.')
         assert_exist_and_clean(fn, "fn, plot and path")
+
+    @pytest.mark.skip("Results of this test can only be confirmed by"
+                      "inspecting the generated PDF.")
+    def test_height_width(self):
+        plots = []
+        for i, plot in enumerate(p()):
+            plots.append(plot + theme(figure_size=(8+i, 6+i)))
+        fn = next(filename_gen)
+        save_as_pdf_pages(plots, fn)
+        # assert False, "Check %s" % fn  # Uncomment to check
 
 
 class TestExceptions(object):

--- a/plotnine/tests/test_save_as_pdf_pages.py
+++ b/plotnine/tests/test_save_as_pdf_pages.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import, division, print_function
+import os
+
+import matplotlib.pyplot as plt
+import pytest
+import six
+
+from plotnine import ggplot, aes, geom_text, ggtitle
+from plotnine.data import mtcars
+from plotnine.ggplot import save_as_pdf_pages
+
+
+def p(N=3):
+    """Return *N* distinct plot objects."""
+    template = (
+        ggplot(aes(x='wt', y='mpg', label='name'), data=mtcars) +
+        geom_text()
+        )
+    for i in range(1, N+1):
+        yield template + ggtitle('%d of %d' % (i, N))
+
+
+def sequential_filenames():
+    """
+    Generate filenames for the tests
+    """
+    for i in range(100):
+        yield 'filename-{}.pdf'.format(i)
+
+
+filename_gen = sequential_filenames()
+
+
+def assert_file_exist(filename, msg=None):
+    if not msg:
+        msg = "File {} does not exist".format(filename)
+    assert os.path.exists(filename), msg
+
+
+def assert_exist_and_clean(filename, msg=None):
+    assert_file_exist(filename, msg=None)
+    os.remove(filename)
+
+
+class TestArguments(object):
+    def test_default_filename(self):
+        plots = list(p())
+        save_as_pdf_pages(plots)
+        fn = plots[0]._save_filename('pdf')
+        assert_exist_and_clean(fn, "default filename")
+
+    @pytest.mark.skipif(six.PY2,
+                        reason="pesky string complications in py2")
+    def test_save_method(self):
+        fn = next(filename_gen)
+        with pytest.warns(UserWarning) as record:
+            save_as_pdf_pages(p(), fn)
+
+        assert_exist_and_clean(fn, "save method")
+
+        res = ('filename' in str(item.message).lower()
+               for item in record)
+        assert any(res)
+
+        # verbose
+        fn = next(filename_gen)
+        with pytest.warns(None) as record:
+            save_as_pdf_pages(p(), fn, verbose=False)
+        assert_exist_and_clean(fn, "save method")
+
+        res = ('filename' in str(item.message).lower()
+               for item in record)
+        assert not any(res)
+
+    def test_filename_plot_path(self):
+        fn = next(filename_gen)
+        save_as_pdf_pages(p(), fn, path='.')
+        assert_exist_and_clean(fn, "fn, plot and path")
+
+
+class TestExceptions(object):
+    def test_bad_object(self):
+        # Iterable includes elements that are not ggplot objects
+        plots = list(p()) + ['foo']
+        with pytest.raises(TypeError):
+            save_as_pdf_pages(plots)
+
+
+# This should be the last function in the file since it can catch
+# "leakages" due to the tests in this test module.
+def test_save_as_pdf_pages_closes_plots():
+    assert plt.get_fignums() == [], "There are unsaved test plots"
+    fn = next(filename_gen)
+    save_as_pdf_pages(p(), fn)
+    assert_exist_and_clean(fn, "exist")
+    assert plt.get_fignums() == [], "ggplot.save did not close the plot"

--- a/plotnine/tests/test_save_as_pdf_pages.py
+++ b/plotnine/tests/test_save_as_pdf_pages.py
@@ -8,6 +8,7 @@ import six
 from plotnine import ggplot, aes, geom_text, ggtitle
 from plotnine.data import mtcars
 from plotnine.ggplot import save_as_pdf_pages
+from plotnine.exceptions import PlotnineError
 
 
 def p(N=3):
@@ -83,6 +84,13 @@ class TestExceptions(object):
         # Iterable includes elements that are not ggplot objects
         plots = list(p()) + ['foo']
         with pytest.raises(TypeError):
+            save_as_pdf_pages(plots)
+
+    def test_plot_exception(self):
+        # Force an error in drawing
+        plots = list(p())
+        plots[0] += aes(color='unknown')
+        with pytest.raises(PlotnineError):
             save_as_pdf_pages(plots)
 
 


### PR DESCRIPTION
As discussed in #133.

- [x] I added some tests for the new code. Should I move these into `test_ggsave.py` instead of the separate file they are currently in? Also look at the Travis report of test coverage.
- [x] Document and/or test setting `height`, `width` and/or `dpi` of the individual plots/pages. This is handled by `ggplot.draw()` and then respected by `PdfPages.savefig()`.
- [x] Expand docstring with both list and generator examples of using the method, to appear in the public docs.