### PR TITLE
DOC: themeable axis_text_y fix y-axis tick labels typo

### DIFF
--- a/plotnine/themes/themeable.py
+++ b/plotnine/themes/themeable.py
@@ -663,7 +663,7 @@ class axis_text_x(themeable):
 
 class axis_text_y(themeable):
     """
-    x-axis tick labels
+    y-axis tick labels
 
     Parameters
     ----------


### PR DESCRIPTION
Correct docstring for themable/axis_text_y: x-axis tick labels -> y-axis tick labels