### PR TITLE
Allow turning of jitter in position_jitter

### DIFF
--- a/plotnine/positions/position_jitter.py
+++ b/plotnine/positions/position_jitter.py
@@ -31,9 +31,9 @@ class position_jitter(position):
 
     def setup_params(self, data):
         params = deepcopy(self.params)
-        if not params['width']:
+        if params['width'] is None:
             params['width'] = resolution(data['x']) * .4
-        if not params['height']:
+        if params['height'] is None:
             params['height'] = resolution(data['y']) * .4
         if not params['random_state']:
             params['random_state'] = np.random


### PR DESCRIPTION
position_jitter right now does not allow you to selectively turn of jitter for x or y,
but I often want to jitter just the categorical x axis, not my y-values.

Example:

```python
import pandas
from plotnine import *
df = pandas.DataFrame({"x": [1,2,3]})
ggplot(df) + geom_jitter(aes('x','x'), width=0, height=0)
```
looks like this, note jitter on both axes:
![image](https://user-images.githubusercontent.com/1257580/46205980-dc78aa80-c322-11e8-834a-509fd05507f9.png)

Work around is to set jitter to a small but non-falsy value - that's kind of unintuitive.

This pull request changes the parameter handing to only substitute the default value on None (=default parameter), instead of anything that evaluates to False.

Thanks!

