### PR TITLE
annotate accepts name or geom-descendant class as first parameter

### DIFF
--- a/plotnine/geoms/annotate.py
+++ b/plotnine/geoms/annotate.py
@@ -78,12 +78,18 @@ class annotate:
                 break
 
         data = pd.DataFrame(position)
-        if isinstance(geom_cls_or_name, str):
-            geom_to_use = Registry['geom_{}'.format(geom_cls_or_name)]
-        elif isinstance(geom_cls_or_name, type) and issubclass(geom_cls_or_name, geom.geom):
-            geom_to_use = geom_cls_or_name
-        else:
-            raise PlotnineError("geom_cls_or_name must either be a geom.geom() descendant (e.g. plotnine.geom_point), or a string naming a geom (e.g. 'point', 'text', ...). Was {}".format(geom_cls_or_name))
+        try:
+            if isinstance(geom_cls_or_name, str):
+                geom_to_use = Registry['geom_{}'.format(geom_cls_or_name)]
+            elif isinstance(geom_cls_or_name, type) and issubclass(geom_cls_or_name, geom.geom):
+                geom_to_use = geom_cls_or_name
+            else:
+                raise PlotnineError() # error message comes below
+        except PlotnineError:
+            raise PlotnineError("geom_cls_or_name must either be a geom.geom() " +
+                             "descendant (e.g. plotnine.geom_point), or " +
+                             "a string naming a geom (e.g. 'point', 'text', " +
+                             "...). Was {}".format(repr(geom_cls_or_name)))
         mappings = aes(**{ae: ae for ae in data.columns})
 
         # The positions are mapped, the rest are manual settings

--- a/plotnine/geoms/annotate.py
+++ b/plotnine/geoms/annotate.py
@@ -3,7 +3,7 @@ import pandas as pd
 from ..aes import aes
 from ..utils import is_scalar_or_string, Registry
 from ..exceptions import PlotnineError
-from ..geoms import geom
+from ..geoms.geom import geom as geom_base_class
 
 
 class annotate:
@@ -12,7 +12,7 @@ class annotate:
 
     Parameters
     ----------
-    geom_cls_or_name : geom
+    geom : geom or str
         Name of geom (e.g. 'point') as string, or geom_* class to use for annotation
     x : float
         Position
@@ -42,7 +42,7 @@ class annotate:
     All `geoms` are created with :code:`stat='identity'`.
     """
 
-    def __init__(self, geom_cls_or_name, x=None, y=None,
+    def __init__(self, geom, x=None, y=None,
                  xmin=None, xmax=None, xend=None,
                  ymin=None, ymax=None, yend=None,
                  **kwargs):
@@ -79,26 +79,27 @@ class annotate:
 
         data = pd.DataFrame(position)
         try:
-            if isinstance(geom_cls_or_name, str):
-                geom_to_use = Registry['geom_{}'.format(geom_cls_or_name)]
-            elif isinstance(geom_cls_or_name, type) and issubclass(geom_cls_or_name, geom.geom):
-                geom_to_use = geom_cls_or_name
+            if isinstance(geom, str):
+                geom_to_use = Registry['geom_{}'.format(geom)]
+            elif isinstance(geom, type) and issubclass(geom, geom_base_class):
+                geom_to_use = geom
             else:
                 raise PlotnineError() # error message comes below
         except PlotnineError:
-            raise PlotnineError("geom_cls_or_name must either be a geom.geom() " +
-                             "descendant (e.g. plotnine.geom_point), or " +
-                             "a string naming a geom (e.g. 'point', 'text', " +
-                             "...). Was {}".format(repr(geom_cls_or_name)))
+            raise PlotnineError(
+                "geom_cls_or_name must either be a geom.geom() "
+                "descendant (e.g. plotnine.geom_point), or "
+                "a string naming a geom (e.g. 'point', 'text', "
+                "...). Was {}".format(repr(geom)))
         mappings = aes(**{ae: ae for ae in data.columns})
 
         # The positions are mapped, the rest are manual settings
         self._annotation_geom = geom_to_use(mappings,
-                                     data=data,
-                                     stat='identity',
-                                     inherit_aes=False,
-                                     show_legend=False,
-                                     **kwargs)
+            data=data,
+            stat='identity',
+            inherit_aes=False,
+            show_legend=False,
+            **kwargs)
 
     def __radd__(self, gg, inplace=False):
         return self._annotation_geom.__radd__(gg, inplace=inplace)

--- a/plotnine/tests/test_annotate.py
+++ b/plotnine/tests/test_annotate.py
@@ -1,6 +1,8 @@
 import pandas as pd
+import pytest
 
 from plotnine import ggplot, aes, geom_point, annotate
+from plotnine.exceptions import PlotnineError
 
 n = 4
 df = pd.DataFrame({'x': range(n),
@@ -19,3 +21,30 @@ def test_multiple_annotation_geoms():
                   yend=4.2, color='red', size=1))
 
     assert p == 'multiple_annotation_geoms'
+
+def test_multiple_annotation_geoms_using_classes():
+    from plotnine import geom_point, geom_text, geom_rect, geom_segment
+    p = (ggplot(df, aes('x', 'y')) +
+         geom_point() +
+         annotate(geom_point, 0, 1, color='red', size=5) +
+         annotate(geom_text, 1, 2, label='Text', color='red',
+                  size=15, angle=45) +
+         annotate(geom_rect, xmin=1.8, xmax=2.2, ymin=2.8,
+                  ymax=3.2, size=1, color='red', alpha=0.3) +
+         annotate(geom_segment, x=2.8, y=3.8, xend=3.2,
+                  yend=4.2, color='red', size=1))
+
+    assert p == 'multiple_annotation_geoms'
+
+def test_non_geom_raises():
+    from plotnine import geom_point
+    with pytest.raises(PlotnineError):
+        annotate('doesnotexist', x=1)
+    with pytest.raises(PlotnineError):
+        annotate(5, x=1)
+    class NotAGeom():
+        pass
+    with pytest.raises(PlotnineError):
+        annotate(NotAGeom, x=1)
+    with pytest.raises(PlotnineError):
+        annotate(geom_point(), x=1)

--- a/plotnine/tests/test_annotate.py
+++ b/plotnine/tests/test_annotate.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from plotnine import ggplot, aes, geom_point, annotate
+from plotnine import ggplot, aes, geom_point, geom_rect, geom_segment, annotate
 from plotnine.exceptions import PlotnineError
 
 n = 4
@@ -15,36 +15,22 @@ def test_multiple_annotation_geoms():
          annotate('point', 0, 1, color='red', size=5) +
          annotate('text', 1, 2, label='Text', color='red',
                   size=15, angle=45) +
-         annotate('rect', xmin=1.8, xmax=2.2, ymin=2.8,
-                  ymax=3.2, size=1, color='red', alpha=0.3) +
-         annotate('segment', x=2.8, y=3.8, xend=3.2,
-                  yend=4.2, color='red', size=1))
-
-    assert p == 'multiple_annotation_geoms'
-
-def test_multiple_annotation_geoms_using_classes():
-    from plotnine import geom_point, geom_text, geom_rect, geom_segment
-    p = (ggplot(df, aes('x', 'y')) +
-         geom_point() +
-         annotate(geom_point, 0, 1, color='red', size=5) +
-         annotate(geom_text, 1, 2, label='Text', color='red',
-                  size=15, angle=45) +
-         annotate(geom_rect, xmin=1.8, xmax=2.2, ymin=2.8,
+        annotate(geom_rect, xmin=1.8, xmax=2.2, ymin=2.8,
                   ymax=3.2, size=1, color='red', alpha=0.3) +
          annotate(geom_segment, x=2.8, y=3.8, xend=3.2,
                   yend=4.2, color='red', size=1))
-
     assert p == 'multiple_annotation_geoms'
+
 
 def test_non_geom_raises():
     from plotnine import geom_point
     with pytest.raises(PlotnineError):
         annotate('doesnotexist', x=1)
     with pytest.raises(PlotnineError):
-        annotate(5, x=1)
+        annotate(5)
     class NotAGeom():
         pass
     with pytest.raises(PlotnineError):
-        annotate(NotAGeom, x=1)
+        annotate(NotAGeom)
     with pytest.raises(PlotnineError):
-        annotate(geom_point(), x=1)
+        annotate(geom_point())


### PR DESCRIPTION
Improve annotate() to accept either a geom_* class (descendant of geom()) or the
previous string-based geom definition (as in ggplot2).

Includes test cases and improved exception.