### PR TITLE
Plotnine warnings cherry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ install:
     fi
   - |
     if [[ "$JOB" == "UNITTEST" ]]; then
-      conda install pytest-cov pyshp
+      conda install pytest-cov
+      conda install -c conda-forge "pyshp>=2.0.0" # temporary
       pip install coveralls
     elif [[ "$JOB" == "DOCS" ]]; then
       pip install -r requirements/doc.txt

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,13 @@ v0.5.2
 ------
 (not-yet-released)
 
+API Changes
+***********
+
+- The ``draw`` parameter of :class:`plotnine.geoms.geom_map` has been removed.
+  Shapefiles should contain only one type of geometry and that is the geometry
+  that is drawn.
+
 Bug Fixes
 *********
 

--- a/doc/changelog.rst.orig
+++ b/doc/changelog.rst.orig
@@ -1,0 +1,367 @@
+Changelog
+=========
+
+v0.5.2
+------
+(not-yet-released)
+
+<<<<<<< HEAD
+API Changes
+***********
+
+- The ``draw`` parameter of :class:`plotnine.geoms.geom_map` has been removed.
+  Shapefiles should contain only one type of geometry and that is the geometry
+  that is drawn.
+
+=======
+>>>>>>> Fixed annotate & facetting plus namespace variable
+Bug Fixes
+*********
+
+- Fixed bug where facetting would fail if done on a plot with annotation(s)
+  and one of the facetting columns was also a variable in the environment.
+
+v0.5.1
+------
+(2018-10-17)
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1464803.svg
+   :target: https://doi.org/10.5281/zenodo.1464803
+
+Bug Fixes
+*********
+
+- Changed the dependency for mizani to ``v0.5.2``. This fixes an issue
+  where facetting may create plots with missing items. (:issue:`210`)
+
+v0.5.0
+------
+(2018-10-16)
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.89276692.svg
+   :target: https://doi.org/10.5281/zenodo.89276692
+
+API Changes
+***********
+
+- Plotnine 0.5.0 only supports Python 3.5 and higher
+- geopandas has been removed as a requirement for installation. Users of
+  :class:`~plotnine.geoms.geom_map` will have to install it separately.
+  (:issue:`178`)
+
+Bug Fixes
+*********
+
+- Fixed issue where with the `subplots_adjust` themeable could not be used to
+  set the `wspace` and `hspace` Matplotlib subplot parameters. (:issue:`185`)
+
+- Fixed in :class:`~plotnine.stat.stat_bin` where setting custom limits for the
+  scale leads to an error. (:issue:`189`)
+
+- Fixed issue interactive plots where the x & y coordinates of the mouse do not
+  show. (:issue:`187`)
+
+- Fixed bug in :class:`~plotnine.geoms.geom_abline` where passing the mapping as
+  a keyword parameter lead to a wrong plot. (:issue:`196`)
+
+- Fixed issue where ``minor_breaks`` for tranformed scaled would have to be given
+  in the transformed coordinates. Know they are given the data coordinates just
+  like the major ``breaks``.
+
+Enhancements
+************
+
+- For all geoms, with :class:`~plotnine.coords.coord_cartesian` ``float('inf')``
+  or ``np.inf`` are interpreted as the boundary of the plot panel.
+
+- Discrete scales now show missing data (``None`` and ``nan``). This behaviour
+  is controlled by the new ``na_translate`` option.
+
+- The ``minor_breaks`` parameter for continuous scales can now be given as an
+  integer. An integer is taken to controll the number of minor breaks between
+  any set of major breaks.
+
+v0.4.0
+------
+*2018-01-08*
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1325309.svg
+   :target: https://doi.org/10.5281/zenodo.1325309
+
+API Changes
+***********
+
+- Calculated aesthetics are accessed using the :func:`~plotnine.aes.stat`
+  function. The old method (double dots ``..name..``) still works.
+
+- :class:`~plotnine.stats.stat_qq` calculates slightly different points
+  for the theoretical quantiles.
+
+- The ``scales`` (when set to *free*, *free_x* or *free_y*') parameter of
+  :class:`~plotnine.facets.facet_grid` and :class:`~plotnine.facets.facet_wrap`
+  assigns the same scale across the rows and columns.
+
+
+New Features
+************
+
+- Added :class:`~plotnine.geoms.geom_qq_line` and
+  :class:`~plotnine.stats.stat_qq_line`, for lines through Q-Q plots.
+
+- Added :class:`~plotnine.geoms.geom_density_2d` and
+  :class:`~plotnine.geoms.geom_stat_2d`.
+
+- Added :class:`~plotnine.stats.stat_ellipse`.
+
+- Added :class:`~plotnine.geom.geom_map`.
+
+- Plotnine learned to respect plydata groups.
+
+- Added :class:`~plotnine.stats.stat_hull`.
+
+- Added :meth:`~plotnine.ggplot.save_as_pdf_pages`.
+
+Bug Fixes
+*********
+
+- Fixed issue where colorbars may chop off the colors at the limits
+  of a scale.
+
+- Fixed issue with creating fixed mappings to datetime and timedelta
+  type values.(:issue:`88`)
+
+- Fixed :class:`~plotnine.scales.scale_x_datetime` and
+  :class:`~plotnine.scales.scale_y_datetime` to handle the intercepts
+  along the axes (:issue:`97`).
+
+- Fixed :class:`~plotnine.stats.stat_bin` and
+  :class:`~plotnine.stats.stat_bin_2d` to properly handle the
+  ``breaks`` parameter when used with a transforming scale.
+
+- Fixed issue with x and y scales where the ``name`` of the scale was
+  ignored when determining the axis titles. Now, the ``name`` parameter
+  is specified, it is used as the title. (:issue:`105`)
+
+- Fixed bug in discrete scales where a column could not be mapped
+  to integer values. (:issue:`108`)
+
+- Make it possible to hide the legend with ``theme(legend_position='none')``.
+  (:issue:`119`)
+
+- Fixed issue in :class:`~plotnine.stats.stat_summary_bin` where some input
+  values gave an error. (:issue:`123`)
+
+- Fixed :class:`~plotnine.geoms.geom_ribbon` to sort data before plotting.
+  (:issue:`127`)
+
+- Fixed ``IndexError`` in :class:`~plotnine.facets.facet_grid` when row/column
+  variable has 1 unique value. (:issue:`129`)
+
+- Fixed :class:`~plotnine.facets.facet_grid` when ``scale='free'``,
+  ``scale='free_x'`` or ``scale='free_y'``, the panels share axes
+  along the row or column.
+
+- Fixed :class:`~plotnine.geoms.geom_boxplot` so that user can create a boxplot
+  by specifying all required aesthetics. (:issue:`136`)
+
+- Fixed :class:`~plotnine.geoms.geom_violin` to work when some groups are empty.
+  (:issue:`131`)
+
+- Fixed continuous scales to accept ``minor=None`` (:issue:`120`)
+
+- Fixed bug for discrete position scales, where ``drop=False`` did not drop
+  unused categories (:issue:`139`)
+
+- Fixed bug in :class:`~plotnine.stats.stat_ydensity` that caused an exception
+  when a panel had no data. (:issue:`147`)
+
+- Fixed bug in :class:`~plotnine.coords.coord_trans` where coordinate
+  transformation and facetting could fail with a ``KeyError``. (:issue:`151`)
+
+- Fixed bug that lead to a ``TypeError`` when aesthetic mappings to could be
+  recognised as being groupable. It was easy to stumble on this bug when using
+  :class:`~plotnine.geoms.geom_density`. (:issue:`165`)
+
+- Fixed bug in :class:`~plotnine.facets.facet_wrap` where some combination of
+  parameters lead to unexpected panel arrangements. (:issue:`163`)
+
+- Fixed bug where the legend text of colorbars could not be themed. (:issue:`171`)
+
+v0.3.0
+------
+*(2017-11-08)*
+
+API Changes
+***********
+
+- :class:`~plotnine.geoms.geom_smooth` gained an extra parameter
+  ``legend_fill_ratio`` that control the area of the legend that is filled
+  to indicate confidence intervals. (:issue:`32`)
+
+- :meth:`plotnine.ggplot.save` gained an extra parameter ``verbose``.
+  It no longer guesses when to print information and when not to.
+
+- :meth:`plotnine.ggplot.draw` gained an extra parameter ``return_ggplot``.
+
+- If the ``minor_breaks`` parameter of scales is a callable, it now
+  expects one argument, the ``limits``. Previously it accepted
+  ``breaks`` and ``limits``.
+
+New Features
+************
+
+- Added :class:`~plotnine.animation.PlotnineAnimation` for animations.
+- Added :class:`~plotnine.watermark.watermark` for watermarks.
+- Added datetime scales for ``alpha``, ``colour``, ``fill`` and ``size``
+  aesthetics
+
+Enhancements
+************
+
+- Changed parameter settings for :class:`~plotnine.stats.stat_smooth`.
+
+  #. Default ``span=0.75`` instead of ``2/3``
+  #. When using loess smoothing, the control parameter ``surface``
+     is only set to the value ``'direct'`` if predictions will
+     be made outside the data range.
+
+
+- Better control of scale limits. You can now specify individual limits of a scale.
+
+  .. code-block:: python
+
+     scale_y_continuous(limits=(0, None))
+     xlim(None, 100)
+
+  You can also use :func:`~plotnine.scales.expand_limits`
+
+- Low and high :class:`~plotnine.scales.scale` limits can now be expanded
+  separately with different factors multiplicative and additive factors.
+
+- The layer parameter `show_legend` can now accept a ``dict`` for finer
+  grained control of which aesthetics to exclude in the legend.
+
+- Infinite values are removed before statistical computations ``stats``
+  (:issue:`40`).
+
+  ``stats`` also gained new parameter ``na_rm``, that controls whether
+  missing values are removed before statistical computations.
+
+- :func:`~plotnine.qplot` can now use the name and a Pandas series to
+  label the scales of the aesthetics.
+
+- You can now put stuff to add to a ggplot object into a list and add that
+  that instead. No need to wrap the list around the internal class
+  `Layers`.
+
+  .. code-block:: python
+
+     lst = [geom_point(), geom_line()]
+     g = ggplot(df, aes('x', 'y'))
+     print(g + lst)
+
+  Using a list allows you to bundle up objects. I can be convenient when
+  creating some complicated plots. See the Periodic Table Example.
+
+- You can now use a ``dict`` (with manual scales) to map data values to
+  aesthetics (:issue:`169`).
+
+- You can now specify infinite coordinates with :class:`plotnine.geoms.geom_rect`
+  (:issue:`166`)
+
+Bug Fixes
+*********
+
+- Fixed bug where facetting led to a reordering of the data. This
+  would manifest as a bug for ``geoms`` where order was important.
+  (:issue:`26`)
+
+- Fix bug where facetting by a column whose name (eg. ``class``) is
+  a python keyword resulted in an exception. (:issue:`28`)
+
+- Fix bug where y-axis scaling was calculated from the ``xlim`` argument.
+
+- Fix bug where initialising geoms from stats, and positions from geoms,
+  when passed as classes (e.g. ``stat_smooth(geom=geom_point)``, would
+  fail.
+
+- Fixed bug in :meth:`plotnine.ggplot.save` where specifying the ``width``
+  and ``height`` would mess up the ``strip_text`` and ``spacing`` for the
+  facetted plots. (:issue:`44`).
+
+- Fixed bug in :class:`~plotnine.geoms.geom_abline`,
+  :class:`~plotnine.geoms.geom_hline` and :class:`~plotnine.geoms.geom_vline`
+  where facetting on a column that is not mapped to an aesthetic fails.
+  (:issue:`48`)
+
+- Fixed bug in :class:`~plotnine.geoms.geom_text`, the ``fontstyle`` parameter
+  was being ignored.
+
+- Fixed bug where boolean data was mapped to the same value on the coordinate
+  axis. (:issue:`57`)
+
+- Fixed bug in :class:`~plotnine.facets.facet_grid` where the ``scales``
+  sometimes has no effect. (:issue:`58`)
+
+- Fixed bug in :class:`~plotnine.stats.stat_boxplot` where setting the
+  ``width`` parameter caused an exception.
+
+
+v0.2.1
+------
+*(2017-06-22)*
+
+- Fixed bug where manually setting the aesthetic ``fill=None`` or
+  ``fill='None'`` could lead to a black fill instead of an empty
+  fill.
+
+- Fixed bug where computed aesthetics could not be used in larger
+  statements. (:issue:`7`)
+
+- Fixed bug in :class:`~plotnine.stats.stat_summary` where the you got
+  an exception for some types of the `x` aesthetic values.
+
+- Fixed bug where ``ggplot(data=df)`` resulted in an exception.
+
+- Fixed missing axis ticks and labels for :class:`~plotnine.facets.facet_wrap`
+  when the scales are allowed to vary (e.g `scales='free'`) between
+  the panels.
+
+- Fixed bug in :class:`~plotnine.stats.stat_density` where changing the
+  x limits lead to an exception (:issue:`22`)
+
+
+v0.2.0
+------
+*(2017-05-18)*
+
+- Fixed bug in :class:`~plotnine.scales.scale_x_discrete` and
+  :class:`~plotnine.scales.scale_y_discrete` where if they were
+  instantiated with parameter ``limits`` that is either a numpy
+  array or a pandas series, plotting would fail with a
+  :class:`ValueError`.
+
+- Fixed exceptions when using :func:`pandas.pivot_table` for Pandas v0.20.0.
+  The API was `fixed <http://pandas.pydata.org/pandas-docs/version/0.20/whatsnew.html#pivot-table-always-returns-a-dataframe>`_.
+
+- Fixed issues where lines/paths with segments that all belonged in the
+  same group had joins that in some cases were "butted".
+
+
+API Changes
+***********
+
+- :class:`~plotnine.geoms.geom_text` now uses ``ha`` and ``va`` as
+  parameter names for the horizontal and vertical alignment. This
+  is what matplotlib users expect. The previous names ``hjust`` and
+  ``vjust`` are silently accepted.
+
+- :func:`~plotnine.layer.Layers` can now be used to bundle up ``geoms``
+  and ``stats``. This makes it easy to reuse ``geoms`` and `stats` or
+  organise them in sensible bundles when making complex plots.
+
+v0.1.0
+------
+*(2017-04-25)*
+
+First public release

--- a/plotnine/__init__.py
+++ b/plotnine/__init__.py
@@ -12,6 +12,7 @@ from .facets import *               # noqa: F401,F403,E261
 from .themes import *               # noqa: F401,F403,E261
 from .positions import *            # noqa: F401,F403,E261
 from .guides import *               # noqa: F401,F403,E261
+from .exceptions import *           # noqa: F401,F403,E261
 
 from ._version import get_versions
 

--- a/plotnine/__init__.py
+++ b/plotnine/__init__.py
@@ -12,7 +12,6 @@ from .facets import *               # noqa: F401,F403,E261
 from .themes import *               # noqa: F401,F403,E261
 from .positions import *            # noqa: F401,F403,E261
 from .guides import *               # noqa: F401,F403,E261
-from .exceptions import *           # noqa: F401,F403,E261
 
 from ._version import get_versions
 

--- a/plotnine/coords/coord_trans.py
+++ b/plotnine/coords/coord_trans.py
@@ -6,6 +6,7 @@ from mizani.transforms import gettrans
 
 from ..positions.position import transform_position
 from .coord import coord, dist_euclidean
+from ..exceptions import PlotNineWarning
 
 
 class coord_trans(coord):
@@ -42,7 +43,7 @@ class coord_trans(coord):
                                      data, panel_params['x_range'])
             if any(result.isnull()):
                 warn("Coordinate transform of x aesthetic "
-                     "created one or more NaN values.")
+                     "created one or more NaN values.", PlotNineWarning)
             return result
 
         def trans_y(data):
@@ -50,7 +51,7 @@ class coord_trans(coord):
                                      data, panel_params['y_range'])
             if any(result.isnull()):
                 warn("Coordinate transform of y aesthetic "
-                     "created one or more NaN values.")
+                     "created one or more NaN values.", PlotNineWarning)
             return result
 
         data = transform_position(data, trans_x, trans_y)

--- a/plotnine/coords/coord_trans.py
+++ b/plotnine/coords/coord_trans.py
@@ -6,7 +6,7 @@ from mizani.transforms import gettrans
 
 from ..positions.position import transform_position
 from .coord import coord, dist_euclidean
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 class coord_trans(coord):
@@ -43,7 +43,7 @@ class coord_trans(coord):
                                      data, panel_params['x_range'])
             if any(result.isnull()):
                 warn("Coordinate transform of x aesthetic "
-                     "created one or more NaN values.", PlotNineWarning)
+                     "created one or more NaN values.", PlotnineWarning)
             return result
 
         def trans_y(data):
@@ -51,7 +51,7 @@ class coord_trans(coord):
                                      data, panel_params['y_range'])
             if any(result.isnull()):
                 warn("Coordinate transform of y aesthetic "
-                     "created one or more NaN values.", PlotNineWarning)
+                     "created one or more NaN values.", PlotnineWarning)
             return result
 
         data = transform_position(data, trans_x, trans_y)

--- a/plotnine/exceptions.py
+++ b/plotnine/exceptions.py
@@ -31,3 +31,10 @@ class PlotnineError(Exception):
 
     def __str__(self):
         return repr(self.message)
+
+
+class PlotNineWarning(UserWarning):
+    """
+    Warnings for ggplot inconsistencies
+    """
+    pass

--- a/plotnine/exceptions.py
+++ b/plotnine/exceptions.py
@@ -33,7 +33,7 @@ class PlotnineError(Exception):
         return repr(self.message)
 
 
-class PlotNineWarning(UserWarning):
+class PlotnineWarning(UserWarning):
     """
     Warnings for ggplot inconsistencies
     """

--- a/plotnine/facets/facet_wrap.py
+++ b/plotnine/facets/facet_wrap.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import numpy as np
 import pandas as pd
 
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 from ..utils import match, join_keys
 from .facet import facet, combine_vars, layout_null
 from .facet import add_missing_facets, eval_facet_vars
@@ -237,7 +237,7 @@ def check_dimensions(nrow, ncol):
     if nrow is not None:
         if nrow < 1:
             warn("'nrow' must be greater than 0. "
-                 "Your value has been ignored.")
+                 "Your value has been ignored.", PlotNineWarning)
             nrow = None
         else:
             nrow = int(nrow)
@@ -245,7 +245,7 @@ def check_dimensions(nrow, ncol):
     if ncol is not None:
         if ncol < 1:
             warn("'ncol' must be greater than 0. "
-                 "Your value has been ignored.")
+                 "Your value has been ignored.", PlotNineWarning)
             ncol = None
         else:
             ncol = int(ncol)

--- a/plotnine/facets/facet_wrap.py
+++ b/plotnine/facets/facet_wrap.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import numpy as np
 import pandas as pd
 
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 from ..utils import match, join_keys
 from .facet import facet, combine_vars, layout_null
 from .facet import add_missing_facets, eval_facet_vars
@@ -237,7 +237,7 @@ def check_dimensions(nrow, ncol):
     if nrow is not None:
         if nrow < 1:
             warn("'nrow' must be greater than 0. "
-                 "Your value has been ignored.", PlotNineWarning)
+                 "Your value has been ignored.", PlotnineWarning)
             nrow = None
         else:
             nrow = int(nrow)
@@ -245,7 +245,7 @@ def check_dimensions(nrow, ncol):
     if ncol is not None:
         if ncol < 1:
             warn("'ncol' must be greater than 0. "
-                 "Your value has been ignored.", PlotNineWarning)
+                 "Your value has been ignored.", PlotnineWarning)
             ncol = None
         else:
             ncol = int(ncol)

--- a/plotnine/geoms/geom_crossbar.py
+++ b/plotnine/geoms/geom_crossbar.py
@@ -11,6 +11,7 @@ from ..doctools import document
 from .geom import geom
 from .geom_polygon import geom_polygon
 from .geom_segment import geom_segment
+from ..exceptions import PlotNineWarning
 
 
 @document
@@ -79,7 +80,7 @@ class geom_crossbar(geom):
         if has_notch:  # 10 points + 1 closing
             if (any(ynotchlower < ymin) or any(ynotchupper > ymax)):
                 warn("Notch went outside hinges."
-                     " Try setting notch=False.")
+                     " Try setting notch=False.", PlotNineWarning)
 
             notchindent = (1 - notchwidth) * (xmax-xmin)/2
 

--- a/plotnine/geoms/geom_crossbar.py
+++ b/plotnine/geoms/geom_crossbar.py
@@ -11,7 +11,7 @@ from ..doctools import document
 from .geom import geom
 from .geom_polygon import geom_polygon
 from .geom_segment import geom_segment
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 @document
@@ -80,7 +80,7 @@ class geom_crossbar(geom):
         if has_notch:  # 10 points + 1 closing
             if (any(ynotchlower < ymin) or any(ynotchupper > ymax)):
                 warn("Notch went outside hinges."
-                     " Try setting notch=False.", PlotNineWarning)
+                     " Try setting notch=False.", PlotnineWarning)
 
             notchindent = (1 - notchwidth) * (xmax-xmin)/2
 

--- a/plotnine/geoms/geom_dotplot.py
+++ b/plotnine/geoms/geom_dotplot.py
@@ -8,6 +8,7 @@ import matplotlib.lines as mlines
 from ..utils import groupby_apply, to_rgba, resolution
 from ..doctools import document
 from .geom import geom
+from ..exceptions import PlotNineWarning
 
 
 @document
@@ -49,13 +50,13 @@ class geom_dotplot(geom):
         # Issue warnings when parameters don't make sense
         if gp['position'] == 'stack':
             warn("position='stack' doesn't work properly with "
-                 "geom_dotplot. Use stackgroups=True instead.")
+                 "geom_dotplot. Use stackgroups=True instead.", PlotNineWarning)
         if (gp['stackgroups'] and
                 sp['method'] == 'dotdensity' and
                 sp['binpositions'] == 'bygroup'):
             warn("geom_dotplot called with stackgroups=TRUE and "
                  "method='dotdensity'. You probably want to set "
-                 "binpositions='all'")
+                 "binpositions='all'", PlotNineWarning)
 
         if 'width' not in data:
             if sp['width']:

--- a/plotnine/geoms/geom_dotplot.py
+++ b/plotnine/geoms/geom_dotplot.py
@@ -50,7 +50,8 @@ class geom_dotplot(geom):
         # Issue warnings when parameters don't make sense
         if gp['position'] == 'stack':
             warn("position='stack' doesn't work properly with "
-                 "geom_dotplot. Use stackgroups=True instead.", PlotnineWarning)
+                 "geom_dotplot. Use stackgroups=True instead.",
+                 PlotnineWarning)
         if (gp['stackgroups'] and
                 sp['method'] == 'dotdensity' and
                 sp['binpositions'] == 'bygroup'):

--- a/plotnine/geoms/geom_dotplot.py
+++ b/plotnine/geoms/geom_dotplot.py
@@ -8,7 +8,7 @@ import matplotlib.lines as mlines
 from ..utils import groupby_apply, to_rgba, resolution
 from ..doctools import document
 from .geom import geom
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 @document
@@ -50,13 +50,13 @@ class geom_dotplot(geom):
         # Issue warnings when parameters don't make sense
         if gp['position'] == 'stack':
             warn("position='stack' doesn't work properly with "
-                 "geom_dotplot. Use stackgroups=True instead.", PlotNineWarning)
+                 "geom_dotplot. Use stackgroups=True instead.", PlotnineWarning)
         if (gp['stackgroups'] and
                 sp['method'] == 'dotdensity' and
                 sp['binpositions'] == 'bygroup'):
             warn("geom_dotplot called with stackgroups=TRUE and "
                  "method='dotdensity'. You probably want to set "
-                 "binpositions='all'", PlotNineWarning)
+                 "binpositions='all'", PlotnineWarning)
 
         if 'width' not in data:
             if sp['width']:

--- a/plotnine/geoms/geom_path.py
+++ b/plotnine/geoms/geom_path.py
@@ -12,7 +12,7 @@ from ..doctools import document
 from ..utils import to_rgba, make_line_segments
 from ..utils import SIZE_FACTOR, match
 from .geom import geom
-
+from ..exceptions import PlotNineWarning
 
 @document
 class geom_path(geom):
@@ -71,7 +71,7 @@ class geom_path(geom):
 
         if (n2 != n1 and not self.params['na_rm']):
             msg = "geom_path: Removed {} rows containing missing values."
-            warn(msg.format(n1-n2))
+            warn(msg.format(n1-n2), PlotNineWarning)
 
         return data
 
@@ -79,7 +79,7 @@ class geom_path(geom):
         if not any(data['group'].duplicated()):
             warn("geom_path: Each group consist of only one "
                  "observation. Do you need to adjust the "
-                 "group aesthetic?")
+                 "group aesthetic?", PlotNineWarning)
 
         # dataframe mergesort is stable, we rely on that here
         data = data.sort_values('group', kind='mergesort')

--- a/plotnine/geoms/geom_path.py
+++ b/plotnine/geoms/geom_path.py
@@ -12,7 +12,7 @@ from ..doctools import document
 from ..utils import to_rgba, make_line_segments
 from ..utils import SIZE_FACTOR, match
 from .geom import geom
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 @document
@@ -72,7 +72,7 @@ class geom_path(geom):
 
         if (n2 != n1 and not self.params['na_rm']):
             msg = "geom_path: Removed {} rows containing missing values."
-            warn(msg.format(n1-n2), PlotNineWarning)
+            warn(msg.format(n1-n2), PlotnineWarning)
 
         return data
 
@@ -80,7 +80,7 @@ class geom_path(geom):
         if not any(data['group'].duplicated()):
             warn("geom_path: Each group consist of only one "
                  "observation. Do you need to adjust the "
-                 "group aesthetic?", PlotNineWarning)
+                 "group aesthetic?", PlotnineWarning)
 
         # dataframe mergesort is stable, we rely on that here
         data = data.sort_values('group', kind='mergesort')

--- a/plotnine/geoms/geom_path.py
+++ b/plotnine/geoms/geom_path.py
@@ -14,7 +14,6 @@ from ..utils import SIZE_FACTOR, match
 from .geom import geom
 from ..exceptions import PlotnineWarning
 
-
 @document
 class geom_path(geom):
     """

--- a/plotnine/geoms/geom_path.py
+++ b/plotnine/geoms/geom_path.py
@@ -14,6 +14,7 @@ from ..utils import SIZE_FACTOR, match
 from .geom import geom
 from ..exceptions import PlotNineWarning
 
+
 @document
 class geom_path(geom):
     """

--- a/plotnine/geoms/geom_path.py
+++ b/plotnine/geoms/geom_path.py
@@ -14,6 +14,7 @@ from ..utils import SIZE_FACTOR, match
 from .geom import geom
 from ..exceptions import PlotnineWarning
 
+
 @document
 class geom_path(geom):
     """

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -19,7 +19,7 @@ from .facets.layout import Layout
 from .options import get_option
 from .themes.theme import theme, theme_get
 from .utils import to_inches, from_inches
-from .exceptions import PlotnineError
+from .exceptions import PlotnineError, PlotNineWarning
 from .scales.scales import Scales
 from .coords import coord_cartesian
 from .guides.guides import guides
@@ -703,8 +703,8 @@ class ggplot:
         if verbose:
             warn("Saving {0} x {1} {2} image.".format(
                  from_inches(width, units),
-                 from_inches(height, units), units))
-            warn('Filename: {}'.format(filename))
+                 from_inches(height, units), units), PlotNineWarning)
+            warn('Filename: {}'.format(filename), PlotNineWarning)
 
         # Helper function so that we can clean up when it fails
         def _save():
@@ -823,7 +823,7 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
         filename = os.path.join(path, filename)
 
     if verbose:
-        warn('Filename: {}'.format(filename))
+        warn('Filename: {}'.format(filename), PlotNineWarning)
 
     with PdfPages(filename) as pdf:
         # Re-add the first element to the iterator, if it was removed

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -19,7 +19,7 @@ from .facets.layout import Layout
 from .options import get_option
 from .themes.theme import theme, theme_get
 from .utils import to_inches, from_inches
-from .exceptions import PlotnineError, PlotNineWarning
+from .exceptions import PlotnineError, PlotnineWarning
 from .scales.scales import Scales
 from .coords import coord_cartesian
 from .guides.guides import guides
@@ -703,8 +703,8 @@ class ggplot:
         if verbose:
             warn("Saving {0} x {1} {2} image.".format(
                  from_inches(width, units),
-                 from_inches(height, units), units), PlotNineWarning)
-            warn('Filename: {}'.format(filename), PlotNineWarning)
+                 from_inches(height, units), units), PlotnineWarning)
+            warn('Filename: {}'.format(filename), PlotnineWarning)
 
         # Helper function so that we can clean up when it fails
         def _save():
@@ -823,7 +823,7 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
         filename = os.path.join(path, filename)
 
     if verbose:
-        warn('Filename: {}'.format(filename), PlotNineWarning)
+        warn('Filename: {}'.format(filename), PlotnineWarning)
 
     with PdfPages(filename) as pdf:
         # Re-add the first element to the iterator, if it was removed

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -845,7 +845,7 @@ def save_as_pdf_pages(plots, filename=None, path=None, verbose=True, **kwargs):
             except AttributeError as err:
                 msg = 'non-ggplot object of %s: %s' % (type(plot), plot)
                 raise TypeError(msg) from err
-            except Exception as err:
+            except Exception:
                 raise
             finally:
                 # Close the figure whether or not there was an exception, to

--- a/plotnine/guides/guide_colorbar.py
+++ b/plotnine/guides/guide_colorbar.py
@@ -15,6 +15,7 @@ from ..aes import rename_aesthetics
 from ..scales.scale import scale_continuous
 from ..utils import ColoredDrawingArea
 from .guide import guide
+from ..exceptions import PlotNineWarning
 
 
 class guide_colorbar(guide):
@@ -61,11 +62,11 @@ class guide_colorbar(guide):
     def train(self, scale):
         # Do nothing if scales are inappropriate
         if set(scale.aesthetics) & {'color', 'colour', 'fill'} == 0:
-            warn("colorbar guide needs color or fill scales.")
+            warn("colorbar guide needs color or fill scales.", PlotNineWarning)
             return None
 
         if not issubclass(scale.__class__, scale_continuous):
-            warn("colorbar guide needs continuous scales")
+            warn("colorbar guide needs continuous scales", PlotNineWarning)
             return None
 
         # value = breaks (numeric) is used for determining the

--- a/plotnine/guides/guide_colorbar.py
+++ b/plotnine/guides/guide_colorbar.py
@@ -15,7 +15,7 @@ from ..aes import rename_aesthetics
 from ..scales.scale import scale_continuous
 from ..utils import ColoredDrawingArea
 from .guide import guide
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 class guide_colorbar(guide):
@@ -62,11 +62,11 @@ class guide_colorbar(guide):
     def train(self, scale):
         # Do nothing if scales are inappropriate
         if set(scale.aesthetics) & {'color', 'colour', 'fill'} == 0:
-            warn("colorbar guide needs color or fill scales.", PlotNineWarning)
+            warn("colorbar guide needs color or fill scales.", PlotnineWarning)
             return None
 
         if not issubclass(scale.__class__, scale_continuous):
-            warn("colorbar guide needs continuous scales", PlotNineWarning)
+            warn("colorbar guide needs continuous scales", PlotnineWarning)
             return None
 
         # value = breaks (numeric) is used for determining the

--- a/plotnine/guides/guide_legend.py
+++ b/plotnine/guides/guide_legend.py
@@ -12,7 +12,7 @@ from matplotlib.offsetbox import (TextArea, HPacker, VPacker)
 from ..scales.scale import scale_continuous
 from ..utils import ColoredDrawingArea, SIZE_FACTOR
 from ..utils import Registry, remove_missing
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 from ..geoms import geom_text
 from ..aes import rename_aesthetics
 from .guide import guide
@@ -120,7 +120,7 @@ class guide_legend(guide):
         self.key = pd.merge(self.key, other.key)
         duplicated = set(self.override_aes) & set(other.override_aes)
         if duplicated:
-            warn("Duplicated override_aes is ignored.")
+            warn("Duplicated override_aes is ignored.", PlotNineWarning)
         self.override_aes.update(other.override_aes)
         for ae in duplicated:
             del self.override_aes[ae]

--- a/plotnine/guides/guide_legend.py
+++ b/plotnine/guides/guide_legend.py
@@ -12,7 +12,7 @@ from matplotlib.offsetbox import (TextArea, HPacker, VPacker)
 from ..scales.scale import scale_continuous
 from ..utils import ColoredDrawingArea, SIZE_FACTOR
 from ..utils import Registry, remove_missing
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 from ..geoms import geom_text
 from ..aes import rename_aesthetics
 from .guide import guide
@@ -120,7 +120,7 @@ class guide_legend(guide):
         self.key = pd.merge(self.key, other.key)
         duplicated = set(self.override_aes) & set(other.override_aes)
         if duplicated:
-            warn("Duplicated override_aes is ignored.", PlotNineWarning)
+            warn("Duplicated override_aes is ignored.", PlotnineWarning)
         self.override_aes.update(other.override_aes)
         for ae in duplicated:
             del self.override_aes[ae]

--- a/plotnine/guides/guides.py
+++ b/plotnine/guides/guides.py
@@ -8,7 +8,7 @@ from matplotlib.offsetbox import (HPacker, VPacker)
 
 from .guide import guide as guide_class
 from ..utils import is_string, is_waive, Registry
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 
 
 # Terminology
@@ -195,7 +195,7 @@ class guides(dict):
                     except KeyError:
                         warn("Cannot generate legend for the {!r} "
                              "aesthetic. Make sure you have mapped a "
-                             "variable to it".format(output))
+                             "variable to it".format(output), PlotNineWarning)
                         continue
 
             # each guide object trains scale within the object,

--- a/plotnine/guides/guides.py
+++ b/plotnine/guides/guides.py
@@ -8,7 +8,7 @@ from matplotlib.offsetbox import (HPacker, VPacker)
 
 from .guide import guide as guide_class
 from ..utils import is_string, is_waive, Registry
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 
 
 # Terminology
@@ -195,7 +195,7 @@ class guides(dict):
                     except KeyError:
                         warn("Cannot generate legend for the {!r} "
                              "aesthetic. Make sure you have mapped a "
-                             "variable to it".format(output), PlotNineWarning)
+                             "variable to it".format(output), PlotnineWarning)
                         continue
 
             # each guide object trains scale within the object,

--- a/plotnine/layer.py
+++ b/plotnine/layer.py
@@ -1,8 +1,9 @@
 from contextlib import suppress
 from copy import copy, deepcopy
+import numbers
 
 import pandas as pd
-import matplotlib.cbook as cbook
+import numpy as np
 import pandas.api.types as pdtypes
 from patsy.eval import EvalEnvironment
 
@@ -514,5 +515,5 @@ def is_known_scalar(value):
         # versions of these types
         return pd.Series(value).dtype.kind in ('M', 'm')
 
-    return not cbook.iterable(value) and (cbook.is_numlike(value) or
-                                          _is_datetime_or_timedelta(value))
+    return not np.iterable(value) and (isinstance(value, numbers.Number) or
+                                       _is_datetime_or_timedelta(value))

--- a/plotnine/positions/position.py
+++ b/plotnine/positions/position.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ..utils import check_required_aesthetics, groupby_apply
 from ..utils import is_string, Registry
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 
 
 class position(metaclass=Registry):
@@ -189,7 +189,7 @@ class position(metaclass=Registry):
         if (len(np.unique(intervals)) > 1 and
                 any(np.diff(intervals - intervals.mean()) < -1e-6)):
             msg = "{} requires non-overlapping x intervals"
-            warn(msg.format(cls.__name__))
+            warn(msg.format(cls.__name__), PlotNineWarning)
 
         if 'ymax' in data:
             data = groupby_apply(data, 'xmin', cls.strategy, params)

--- a/plotnine/positions/position.py
+++ b/plotnine/positions/position.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ..utils import check_required_aesthetics, groupby_apply
 from ..utils import is_string, Registry
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 
 
 class position(metaclass=Registry):
@@ -189,7 +189,7 @@ class position(metaclass=Registry):
         if (len(np.unique(intervals)) > 1 and
                 any(np.diff(intervals - intervals.mean()) < -1e-6)):
             msg = "{} requires non-overlapping x intervals"
-            warn(msg.format(cls.__name__), PlotNineWarning)
+            warn(msg.format(cls.__name__), PlotnineWarning)
 
         if 'ymax' in data:
             data = groupby_apply(data, 'xmin', cls.strategy, params)

--- a/plotnine/positions/position_stack.py
+++ b/plotnine/positions/position_stack.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from ..utils import remove_missing
 from .position import position
+from ..exceptions import PlotNineWarning
 
 
 class position_stack(position):
@@ -28,13 +29,13 @@ class position_stack(position):
         if 'ymax' in data:
             if any((data['ymin'] != 0) & (data['ymax'] != 0)):
                 warn("Stacking not well defined when not "
-                     "anchored on the axis.")
+                     "anchored on the axis.", PlotNineWarning)
             var = 'ymax'
         elif 'y' in data:
             var = 'y'
         else:
             warn("Stacking requires either ymin & ymax or y "
-                 "aesthetics. Maybe you want position = 'identity'?")
+                 "aesthetics. Maybe you want position = 'identity'?", PlotNineWarning)
             var = None
 
         params = self.params.copy()

--- a/plotnine/positions/position_stack.py
+++ b/plotnine/positions/position_stack.py
@@ -74,7 +74,7 @@ class position_stack(position):
         if len(pos):
             pos = cls.collide(pos, params=params)
 
-        data = pd.concat([neg, pos], axis=0, ignore_index=True)
+        data = pd.concat([neg, pos], axis=0, ignore_index=True, sort=True)
         return data
 
     @staticmethod

--- a/plotnine/positions/position_stack.py
+++ b/plotnine/positions/position_stack.py
@@ -35,7 +35,8 @@ class position_stack(position):
             var = 'y'
         else:
             warn("Stacking requires either ymin & ymax or y "
-                 "aesthetics. Maybe you want position = 'identity'?", PlotnineWarning)
+                 "aesthetics. Maybe you want position = 'identity'?",
+                 PlotnineWarning)
             var = None
 
         params = self.params.copy()

--- a/plotnine/positions/position_stack.py
+++ b/plotnine/positions/position_stack.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from ..utils import remove_missing
 from .position import position
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 class position_stack(position):
@@ -29,13 +29,13 @@ class position_stack(position):
         if 'ymax' in data:
             if any((data['ymin'] != 0) & (data['ymax'] != 0)):
                 warn("Stacking not well defined when not "
-                     "anchored on the axis.", PlotNineWarning)
+                     "anchored on the axis.", PlotnineWarning)
             var = 'ymax'
         elif 'y' in data:
             var = 'y'
         else:
             warn("Stacking requires either ymin & ymax or y "
-                 "aesthetics. Maybe you want position = 'identity'?", PlotNineWarning)
+                 "aesthetics. Maybe you want position = 'identity'?", PlotnineWarning)
             var = None
 
         params = self.params.copy()

--- a/plotnine/qplot.py
+++ b/plotnine/qplot.py
@@ -13,7 +13,7 @@ from .facets import facet_null, facet_grid, facet_wrap
 from .facets.facet_grid import parse_grid_facets
 from .facets.facet_wrap import parse_wrap_facets
 from .utils import Registry, is_string, array_kind
-from .exceptions import PlotnineError
+from .exceptions import PlotnineError, PlotNineWarning
 from .scales import scale_x_log10, scale_y_log10
 from .themes import theme
 
@@ -156,7 +156,7 @@ def qplot(x=None, y=None, data=None, facets=None, margins=False,
             return 'wrap'
 
         warn("Could not determine the type of faceting, "
-             "therefore no faceting.")
+             "therefore no faceting.", PlotNineWarning)
         return 'null'
 
     if facets:

--- a/plotnine/qplot.py
+++ b/plotnine/qplot.py
@@ -13,7 +13,7 @@ from .facets import facet_null, facet_grid, facet_wrap
 from .facets.facet_grid import parse_grid_facets
 from .facets.facet_wrap import parse_wrap_facets
 from .utils import Registry, is_string, array_kind
-from .exceptions import PlotnineError, PlotNineWarning
+from .exceptions import PlotnineError, PlotnineWarning
 from .scales import scale_x_log10, scale_y_log10
 from .themes import theme
 
@@ -156,7 +156,7 @@ def qplot(x=None, y=None, data=None, facets=None, margins=False,
             return 'wrap'
 
         warn("Could not determine the type of faceting, "
-             "therefore no faceting.", PlotNineWarning)
+             "therefore no faceting.", PlotnineWarning)
         return 'null'
 
     if facets:

--- a/plotnine/scales/scale.py
+++ b/plotnine/scales/scale.py
@@ -17,7 +17,7 @@ from ..doctools import document
 from ..exceptions import PlotnineError
 from ..utils import match, waiver, is_waive, Registry
 from .range import Range, RangeContinuous, RangeDiscrete
-
+from ..exceptions import PlotNineWarning
 
 class scale(metaclass=Registry):
     """
@@ -86,7 +86,7 @@ class scale(metaclass=Registry):
                 setattr(self, k, v)
             else:
                 msg = "{} could not recognise parameter `{}`"
-                warn(msg.format(self.__class__.__name__, k))
+                warn(msg.format(self.__class__.__name__, k), PlotNineWarning)
 
         self.range = self._range_class()
 

--- a/plotnine/scales/scale.py
+++ b/plotnine/scales/scale.py
@@ -20,6 +20,7 @@ from .range import Range, RangeContinuous, RangeDiscrete
 from ..exceptions import PlotnineWarning
 
 
+
 class scale(metaclass=Registry):
     """
     Base class for all scales

--- a/plotnine/scales/scale.py
+++ b/plotnine/scales/scale.py
@@ -17,7 +17,7 @@ from ..doctools import document
 from ..exceptions import PlotnineError
 from ..utils import match, waiver, is_waive, Registry
 from .range import Range, RangeContinuous, RangeDiscrete
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 class scale(metaclass=Registry):
@@ -87,7 +87,7 @@ class scale(metaclass=Registry):
                 setattr(self, k, v)
             else:
                 msg = "{} could not recognise parameter `{}`"
-                warn(msg.format(self.__class__.__name__, k), PlotNineWarning)
+                warn(msg.format(self.__class__.__name__, k), PlotnineWarning)
 
         self.range = self._range_class()
 

--- a/plotnine/scales/scale.py
+++ b/plotnine/scales/scale.py
@@ -19,6 +19,7 @@ from ..utils import match, waiver, is_waive, Registry
 from .range import Range, RangeContinuous, RangeDiscrete
 from ..exceptions import PlotNineWarning
 
+
 class scale(metaclass=Registry):
     """
     Base class for all scales

--- a/plotnine/scales/scale.py
+++ b/plotnine/scales/scale.py
@@ -20,7 +20,6 @@ from .range import Range, RangeContinuous, RangeDiscrete
 from ..exceptions import PlotnineWarning
 
 
-
 class scale(metaclass=Registry):
     """
     Base class for all scales

--- a/plotnine/scales/scale_color.py
+++ b/plotnine/scales/scale_color.py
@@ -8,6 +8,7 @@ from mizani.palettes import (hue_pal, brewer_pal, grey_pal,
 from ..utils import alias
 from ..doctools import document
 from .scale import scale_discrete, scale_continuous, scale_datetime
+from ..exceptions import PlotNineWarning
 
 
 # Discrete color scales #
@@ -348,7 +349,7 @@ class scale_color_distiller(scale_color_gradientn):
         """
         if type.lower() in ('qual', 'qualitative'):
             warn("Using a discrete color palette in a continuous scale."
-                 "Consider using type = 'seq' or type = 'div' instead")
+                 "Consider using type = 'seq' or type = 'div' instead", PlotNineWarning)
 
         # Grab 6 colors from brewer and create a gradient palette
         colors = brewer_pal(type, palette)(6)

--- a/plotnine/scales/scale_color.py
+++ b/plotnine/scales/scale_color.py
@@ -8,7 +8,7 @@ from mizani.palettes import (hue_pal, brewer_pal, grey_pal,
 from ..utils import alias
 from ..doctools import document
 from .scale import scale_discrete, scale_continuous, scale_datetime
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 # Discrete color scales #
@@ -349,7 +349,7 @@ class scale_color_distiller(scale_color_gradientn):
         """
         if type.lower() in ('qual', 'qualitative'):
             warn("Using a discrete color palette in a continuous scale."
-                 "Consider using type = 'seq' or type = 'div' instead", PlotNineWarning)
+                 "Consider using type = 'seq' or type = 'div' instead", PlotnineWarning)
 
         # Grab 6 colors from brewer and create a gradient palette
         colors = brewer_pal(type, palette)(6)

--- a/plotnine/scales/scale_color.py
+++ b/plotnine/scales/scale_color.py
@@ -349,7 +349,8 @@ class scale_color_distiller(scale_color_gradientn):
         """
         if type.lower() in ('qual', 'qualitative'):
             warn("Using a discrete color palette in a continuous scale."
-                 "Consider using type = 'seq' or type = 'div' instead", PlotnineWarning)
+                 "Consider using type = 'seq' or type = 'div' instead",
+                 PlotnineWarning)
 
         # Grab 6 colors from brewer and create a gradient palette
         colors = brewer_pal(type, palette)(6)

--- a/plotnine/scales/scale_manual.py
+++ b/plotnine/scales/scale_manual.py
@@ -3,6 +3,7 @@ from warnings import warn
 from ..doctools import document
 from ..utils import alias
 from .scale import scale_discrete
+from ..exceptions import PlotNineWarning
 
 
 @document
@@ -23,7 +24,7 @@ class _scale_manual(scale_discrete):
         if n > max_n:
             msg = ("Palette can return a maximum of {} values. "
                    "{} were requested from it.")
-            warn(msg.format(max_n, n))
+            warn(msg.format(max_n, n), PlotNineWarning)
         return self._values
 
 

--- a/plotnine/scales/scale_manual.py
+++ b/plotnine/scales/scale_manual.py
@@ -3,7 +3,7 @@ from warnings import warn
 from ..doctools import document
 from ..utils import alias
 from .scale import scale_discrete
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 @document
@@ -24,7 +24,7 @@ class _scale_manual(scale_discrete):
         if n > max_n:
             msg = ("Palette can return a maximum of {} values. "
                    "{} were requested from it.")
-            warn(msg.format(max_n, n), PlotNineWarning)
+            warn(msg.format(max_n, n), PlotnineWarning)
         return self._values
 
 

--- a/plotnine/scales/scales.py
+++ b/plotnine/scales/scales.py
@@ -5,7 +5,7 @@ from warnings import warn
 import numpy as np
 
 from ..aes import aes_to_scale
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 from ..utils import Registry, array_kind
 
 _TPL_DUPLICATE_SCALE = """\
@@ -25,7 +25,7 @@ class Scales(list):
         ae = sc.aesthetics[0]
         cover_ae = self.find(ae)
         if any(cover_ae):
-            warn(_TPL_DUPLICATE_SCALE.format(ae))
+            warn(_TPL_DUPLICATE_SCALE.format(ae), PlotNineWarning)
             idx = cover_ae.index(True)
             self.pop(idx)
         # super() does not work well with reloads
@@ -284,7 +284,7 @@ def scale_type(series):
     else:
         msg = ("Don't know how to automatically pick scale for "
                "object of type {}. Defaulting to 'continuous'")
-        warn(msg.format(series.dtype))
+        warn(msg.format(series.dtype), PlotNineWarning)
         stype = 'continuous'
     return stype
 

--- a/plotnine/scales/scales.py
+++ b/plotnine/scales/scales.py
@@ -5,7 +5,7 @@ from warnings import warn
 import numpy as np
 
 from ..aes import aes_to_scale
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 from ..utils import Registry, array_kind
 
 _TPL_DUPLICATE_SCALE = """\
@@ -25,7 +25,7 @@ class Scales(list):
         ae = sc.aesthetics[0]
         cover_ae = self.find(ae)
         if any(cover_ae):
-            warn(_TPL_DUPLICATE_SCALE.format(ae), PlotNineWarning)
+            warn(_TPL_DUPLICATE_SCALE.format(ae), PlotnineWarning)
             idx = cover_ae.index(True)
             self.pop(idx)
         # super() does not work well with reloads
@@ -284,7 +284,7 @@ def scale_type(series):
     else:
         msg = ("Don't know how to automatically pick scale for "
                "object of type {}. Defaulting to 'continuous'")
-        warn(msg.format(series.dtype), PlotNineWarning)
+        warn(msg.format(series.dtype), PlotnineWarning)
         stype = 'continuous'
     return stype
 

--- a/plotnine/stats/smoothers.py
+++ b/plotnine/stats/smoothers.py
@@ -5,7 +5,7 @@ import pandas as pd
 import scipy.stats as stats
 import statsmodels.api as sm
 
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 
 smlowess = sm.nonparametric.lowess
 
@@ -80,7 +80,7 @@ def rlm(data, xseq, **params):
 
     if params['se']:
         warnings.warn("Confidence intervals are not yet implemented"
-                      "for RLM smoothing.")
+                      "for RLM smoothing.", PlotNineWarning)
 
     return data
 
@@ -129,7 +129,7 @@ def glm(data, xseq, **params):
         except (AttributeError, TypeError):
             warnings.warn(
                 "Cannot compute confidence intervals."
-                "Install latest/development version of statmodels.")
+                "Install latest/development version of statmodels.", PlotNineWarning)
 
     return data
 
@@ -144,7 +144,7 @@ def lowess(data, xseq, **params):
 
     if params['se']:
         warnings.warn("Confidence intervals are not yet implemented"
-                      "for lowess smoothings.")
+                      "for lowess smoothings.", PlotNineWarning)
 
     return data
 
@@ -171,7 +171,7 @@ def loess(data, xseq, **params):
         kwargs['surface'] = 'direct'
         warnings.warn(
             "Making prediction outside the data range, "
-            "setting loess control parameter `surface='direct'`.")
+            "setting loess control parameter `surface='direct'`.", PlotNineWarning)
 
     if 'span' not in kwargs:
         kwargs['span'] = params['span']
@@ -236,7 +236,7 @@ def gpr(data, xseq, **params):
     if not kwargs:
         warnings.warn(
             "See sklearn.gaussian_process.GaussianProcessRegressor "
-            "for parameters to pass in as 'method_args'")
+            "for parameters to pass in as 'method_args'", PlotNineWarning)
 
     regressor = gaussian_process.GaussianProcessRegressor(**kwargs)
     X = np.atleast_2d(data['x']).T

--- a/plotnine/stats/smoothers.py
+++ b/plotnine/stats/smoothers.py
@@ -5,7 +5,7 @@ import pandas as pd
 import scipy.stats as stats
 import statsmodels.api as sm
 
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 
 smlowess = sm.nonparametric.lowess
 
@@ -80,7 +80,7 @@ def rlm(data, xseq, **params):
 
     if params['se']:
         warnings.warn("Confidence intervals are not yet implemented"
-                      "for RLM smoothing.", PlotNineWarning)
+                      "for RLM smoothing.", PlotnineWarning)
 
     return data
 
@@ -129,7 +129,7 @@ def glm(data, xseq, **params):
         except (AttributeError, TypeError):
             warnings.warn(
                 "Cannot compute confidence intervals."
-                "Install latest/development version of statmodels.", PlotNineWarning)
+                "Install latest/development version of statmodels.", PlotnineWarning)
 
     return data
 
@@ -144,7 +144,7 @@ def lowess(data, xseq, **params):
 
     if params['se']:
         warnings.warn("Confidence intervals are not yet implemented"
-                      "for lowess smoothings.", PlotNineWarning)
+                      "for lowess smoothings.", PlotnineWarning)
 
     return data
 
@@ -171,7 +171,7 @@ def loess(data, xseq, **params):
         kwargs['surface'] = 'direct'
         warnings.warn(
             "Making prediction outside the data range, "
-            "setting loess control parameter `surface='direct'`.", PlotNineWarning)
+            "setting loess control parameter `surface='direct'`.", PlotnineWarning)
 
     if 'span' not in kwargs:
         kwargs['span'] = params['span']
@@ -236,7 +236,7 @@ def gpr(data, xseq, **params):
     if not kwargs:
         warnings.warn(
             "See sklearn.gaussian_process.GaussianProcessRegressor "
-            "for parameters to pass in as 'method_args'", PlotNineWarning)
+            "for parameters to pass in as 'method_args'", PlotnineWarning)
 
     regressor = gaussian_process.GaussianProcessRegressor(**kwargs)
     X = np.atleast_2d(data['x']).T

--- a/plotnine/stats/smoothers.py
+++ b/plotnine/stats/smoothers.py
@@ -129,7 +129,8 @@ def glm(data, xseq, **params):
         except (AttributeError, TypeError):
             warnings.warn(
                 "Cannot compute confidence intervals."
-                "Install latest/development version of statmodels.", PlotnineWarning)
+                "Install latest/development version of statmodels.",
+                PlotnineWarning)
 
     return data
 
@@ -171,7 +172,8 @@ def loess(data, xseq, **params):
         kwargs['surface'] = 'direct'
         warnings.warn(
             "Making prediction outside the data range, "
-            "setting loess control parameter `surface='direct'`.", PlotnineWarning)
+            "setting loess control parameter `surface='direct'`.",
+            PlotnineWarning)
 
     if 'span' not in kwargs:
         kwargs['span'] = params['span']

--- a/plotnine/stats/stat_bin.py
+++ b/plotnine/stats/stat_bin.py
@@ -3,7 +3,7 @@ from warnings import warn
 import numpy as np
 
 from ..doctools import document
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 from .binning import (breaks_from_bins, breaks_from_binwidth,
                       assign_bins, freedman_diaconis_bins)
 from .stat import stat
@@ -90,7 +90,7 @@ class stat_bin(stat):
             params['bins'] = freedman_diaconis_bins(data['x'])
             msg = ("'stat_bin()' using 'bins = {}'. "
                    "Pick better value with 'binwidth'.")
-            warn(msg.format(params['bins']))
+            warn(msg.format(params['bins']), PlotNineWarning)
 
         return params
 

--- a/plotnine/stats/stat_bin.py
+++ b/plotnine/stats/stat_bin.py
@@ -3,7 +3,7 @@ from warnings import warn
 import numpy as np
 
 from ..doctools import document
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 from .binning import (breaks_from_bins, breaks_from_binwidth,
                       assign_bins, freedman_diaconis_bins)
 from .stat import stat
@@ -90,7 +90,7 @@ class stat_bin(stat):
             params['bins'] = freedman_diaconis_bins(data['x'])
             msg = ("'stat_bin()' using 'bins = {}'. "
                    "Pick better value with 'binwidth'.")
-            warn(msg.format(params['bins']), PlotNineWarning)
+            warn(msg.format(params['bins']), PlotnineWarning)
 
         return params
 

--- a/plotnine/stats/stat_bindot.py
+++ b/plotnine/stats/stat_bindot.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from ..utils import groupby_apply
 from ..doctools import document
-from ..exceptions import PlotnineError
+from ..exceptions import PlotnineError, PlotNineWarning
 from .binning import (breaks_from_bins, breaks_from_binwidth,
                       assign_bins, freedman_diaconis_bins)
 from .stat import stat
@@ -98,7 +98,7 @@ class stat_bindot(stat):
             params['bins'] = freedman_diaconis_bins(data['x'])
             msg = ("'stat_bin()' using 'bins = {}'. "
                    "Pick better value with 'binwidth'.")
-            warn(msg.format(params['bins']))
+            warn(msg.format(params['bins']), PlotNineWarning)
 
         return params
 

--- a/plotnine/stats/stat_bindot.py
+++ b/plotnine/stats/stat_bindot.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from ..utils import groupby_apply
 from ..doctools import document
-from ..exceptions import PlotnineError, PlotNineWarning
+from ..exceptions import PlotnineError, PlotnineWarning
 from .binning import (breaks_from_bins, breaks_from_binwidth,
                       assign_bins, freedman_diaconis_bins)
 from .stat import stat
@@ -98,7 +98,7 @@ class stat_bindot(stat):
             params['bins'] = freedman_diaconis_bins(data['x'])
             msg = ("'stat_bin()' using 'bins = {}'. "
                    "Pick better value with 'binwidth'.")
-            warn(msg.format(params['bins']), PlotNineWarning)
+            warn(msg.format(params['bins']), PlotnineWarning)
 
         return params
 

--- a/plotnine/stats/stat_ellipse.py
+++ b/plotnine/stats/stat_ellipse.py
@@ -7,6 +7,7 @@ from scipy import linalg
 
 from ..doctools import document
 from .stat import stat
+from ..exceptions import PlotNineWarning
 
 
 @document
@@ -48,7 +49,7 @@ class stat_ellipse(stat):
         dfd = len(data) - 1
 
         if dfd < 3:
-            warn("Too few points to calculate an ellipse")
+            warn("Too few points to calculate an ellipse", PlotNineWarning)
             return pd.DataFrame({'x': [], 'y': []})
 
         m = np.asarray(data[['x', 'y']])
@@ -209,7 +210,7 @@ def cov_trob(x, wt=None, cor=False, center=True, nu=5, maxit=25,
     else:
         if ((np.mean(w) - np.mean(wt) > tol) or
                 (np.abs(np.mean(w * Q)/p - 1) > tol)):
-            warn("Probable convergence failure.")
+            warn("Probable convergence failure.", PlotNineWarning)
 
     _a = np.sqrt(w) * X
     # cov = (_a.T @ _a) / np.sum(wt)

--- a/plotnine/stats/stat_ellipse.py
+++ b/plotnine/stats/stat_ellipse.py
@@ -7,7 +7,7 @@ from scipy import linalg
 
 from ..doctools import document
 from .stat import stat
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 @document
@@ -49,7 +49,7 @@ class stat_ellipse(stat):
         dfd = len(data) - 1
 
         if dfd < 3:
-            warn("Too few points to calculate an ellipse", PlotNineWarning)
+            warn("Too few points to calculate an ellipse", PlotnineWarning)
             return pd.DataFrame({'x': [], 'y': []})
 
         m = np.asarray(data[['x', 'y']])
@@ -210,7 +210,7 @@ def cov_trob(x, wt=None, cor=False, center=True, nu=5, maxit=25,
     else:
         if ((np.mean(w) - np.mean(wt) > tol) or
                 (np.abs(np.mean(w * Q)/p - 1) > tol)):
-            warn("Probable convergence failure.", PlotNineWarning)
+            warn("Probable convergence failure.", PlotnineWarning)
 
     _a = np.sqrt(w) * X
     # cov = (_a.T @ _a) / np.sum(wt)

--- a/plotnine/stats/stat_quantile.py
+++ b/plotnine/stats/stat_quantile.py
@@ -5,6 +5,7 @@ import statsmodels.formula.api as smf
 
 from ..doctools import document
 from .stat import stat
+from ..exceptions import PlotNineWarning
 
 
 # method_args are any of the keyword args (other than q) for
@@ -57,7 +58,7 @@ class stat_quantile(stat):
         params = self.params.copy()
         if params['formula'] is None:
             params['formula'] = 'y ~ x'
-            warn("Formula not specified, using '{}'")
+            warn("Formula not specified, using '{}'", PlotNineWarning)
         try:
             iter(params['quantiles'])
         except TypeError:

--- a/plotnine/stats/stat_quantile.py
+++ b/plotnine/stats/stat_quantile.py
@@ -5,7 +5,7 @@ import statsmodels.formula.api as smf
 
 from ..doctools import document
 from .stat import stat
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 # method_args are any of the keyword args (other than q) for
@@ -58,7 +58,7 @@ class stat_quantile(stat):
         params = self.params.copy()
         if params['formula'] is None:
             params['formula'] = 'y ~ x'
-            warn("Formula not specified, using '{}'", PlotNineWarning)
+            warn("Formula not specified, using '{}'", PlotnineWarning)
         try:
             iter(params['quantiles'])
         except TypeError:

--- a/plotnine/stats/stat_smooth.py
+++ b/plotnine/stats/stat_smooth.py
@@ -6,6 +6,7 @@ import pandas as pd
 from ..doctools import document
 from .smoothers import predictdf
 from .stat import stat
+from ..exceptions import PlotNineWarning
 
 
 @document
@@ -164,7 +165,7 @@ class stat_smooth(stat):
                     "No 'window' specified in the method_args. "
                     "Using window = {}. "
                     "The same window is used for all groups or "
-                    "facets".format(window))
+                    "facets".format(window), PlotNineWarning)
                 params['method_args']['window'] = window
 
         return params

--- a/plotnine/stats/stat_smooth.py
+++ b/plotnine/stats/stat_smooth.py
@@ -6,7 +6,7 @@ import pandas as pd
 from ..doctools import document
 from .smoothers import predictdf
 from .stat import stat
-from ..exceptions import PlotNineWarning
+from ..exceptions import PlotnineWarning
 
 
 @document
@@ -165,7 +165,7 @@ class stat_smooth(stat):
                     "No 'window' specified in the method_args. "
                     "Using window = {}. "
                     "The same window is used for all groups or "
-                    "facets".format(window), PlotNineWarning)
+                    "facets".format(window), PlotnineWarning)
                 params['method_args']['window'] = window
 
         return params

--- a/plotnine/tests/conftest.py
+++ b/plotnine/tests/conftest.py
@@ -8,7 +8,6 @@ import types
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.testing.compare import compare_images
-from matplotlib import cbook
 
 from plotnine import ggplot, theme
 
@@ -183,7 +182,7 @@ def make_test_image_filenames(name, test_file):
     result_dir = os.path.abspath(os.path.join('result_images', subdir))
 
     if not os.path.exists(result_dir):
-        cbook.mkdirs(result_dir)
+        os.makedirs(result_dir, exist_ok=True)
 
     base, ext = os.path.splitext(name)
     expected_name = '{}-{}{}'.format(base, 'expected', ext)

--- a/plotnine/tests/test_geom_path_line_step.py
+++ b/plotnine/tests/test_geom_path_line_step.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from plotnine import (ggplot, aes, geom_path, geom_line,
-                      geom_step, arrow)
+                      geom_step, arrow, PlotNineWarning)
 
 
 # steps with diagonals at the ends
@@ -72,7 +72,7 @@ def test_missing_values():
     p = (ggplot(df_missing, aes(x='x'))
          + geom_line(aes(y='y1'), size=2))
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(PlotNineWarning):
         assert p == 'missing_values'
 
 

--- a/plotnine/tests/test_geom_path_line_step.py
+++ b/plotnine/tests/test_geom_path_line_step.py
@@ -3,7 +3,8 @@ import pandas as pd
 import pytest
 
 from plotnine import (ggplot, aes, geom_path, geom_line,
-                      geom_step, arrow, PlotNineWarning)
+                      geom_step, arrow)
+from plotnine.exceptions import PlotnineWarning
 
 
 # steps with diagonals at the ends
@@ -72,7 +73,7 @@ def test_missing_values():
     p = (ggplot(df_missing, aes(x='x'))
          + geom_line(aes(y='y1'), size=2))
 
-    with pytest.warns(PlotNineWarning):
+    with pytest.warns(PlotnineWarning):
         assert p == 'missing_values'
 
 

--- a/plotnine/tests/test_geom_smooth.py
+++ b/plotnine/tests/test_geom_smooth.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from plotnine import ggplot, aes, geom_point, geom_smooth
+from plotnine import ggplot, aes, geom_point, geom_smooth, PlotNineWarning
 
 
 random_state = np.random.RandomState(1234567890)
@@ -116,7 +116,7 @@ class TestOther:
 
     def test_rlm(self):
         p = self.p + geom_smooth(aes(y='y_noisy'), method='rlm')
-        with pytest.warns(UserWarning):
+        with pytest.warns(PlotNineWarning):
             p.draw_test()
 
     def test_glm(self):
@@ -129,7 +129,7 @@ class TestOther:
 
     def test_lowess(self):
         p = self.p + geom_smooth(aes(y='y_noisy'), method='lowess')
-        with pytest.warns(UserWarning):
+        with pytest.warns(PlotNineWarning):
             p.draw_test()
 
     def test_mavg(self):

--- a/plotnine/tests/test_geom_smooth.py
+++ b/plotnine/tests/test_geom_smooth.py
@@ -2,7 +2,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from plotnine import ggplot, aes, geom_point, geom_smooth, PlotNineWarning
+from plotnine import ggplot, aes, geom_point, geom_smooth
+from plotnine.exceptions import PlotnineWarning
 
 
 random_state = np.random.RandomState(1234567890)
@@ -116,7 +117,7 @@ class TestOther:
 
     def test_rlm(self):
         p = self.p + geom_smooth(aes(y='y_noisy'), method='rlm')
-        with pytest.warns(PlotNineWarning):
+        with pytest.warns(PlotnineWarning):
             p.draw_test()
 
     def test_glm(self):
@@ -129,7 +130,7 @@ class TestOther:
 
     def test_lowess(self):
         p = self.p + geom_smooth(aes(y='y_noisy'), method='lowess')
-        with pytest.warns(PlotNineWarning):
+        with pytest.warns(PlotnineWarning):
             p.draw_test()
 
     def test_mavg(self):

--- a/plotnine/tests/test_geom_text_label.py
+++ b/plotnine/tests/test_geom_text_label.py
@@ -6,7 +6,7 @@ from plotnine import (ggplot, aes, geom_text, geom_label,
 
 n = 5
 labels = ['ggplot', 'aesthetics', 'data', 'geoms',
-          '$\mathbf{statistics^2}$', 'scales', 'coordinates']
+          r'$\mathbf{statistics^2}$', 'scales', 'coordinates']
 df = pd.DataFrame({
         'x': [1] * n,
         'y': range(n),

--- a/plotnine/tests/test_ggsave.py
+++ b/plotnine/tests/test_ggsave.py
@@ -5,7 +5,7 @@ import pytest
 
 from plotnine import ggplot, aes, geom_text, ggsave
 from plotnine.data import mtcars
-from plotnine.exceptions import PlotnineError
+from plotnine.exceptions import PlotnineError, PlotNineWarning
 
 p = (ggplot(aes(x='wt', y='mpg', label='name'), data=mtcars)
      + geom_text())
@@ -41,7 +41,7 @@ class TestArguments:
 
     def test_save_method(self):
         fn = next(filename_gen)
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(PlotNineWarning) as record:
             p.save(fn)
 
         assert_exist_and_clean(fn, "save method")

--- a/plotnine/tests/test_ggsave.py
+++ b/plotnine/tests/test_ggsave.py
@@ -5,7 +5,7 @@ import pytest
 
 from plotnine import ggplot, aes, geom_text, ggsave
 from plotnine.data import mtcars
-from plotnine.exceptions import PlotnineError, PlotNineWarning
+from plotnine.exceptions import PlotnineError, PlotnineWarning
 
 p = (ggplot(aes(x='wt', y='mpg', label='name'), data=mtcars)
      + geom_text())
@@ -41,7 +41,7 @@ class TestArguments:
 
     def test_save_method(self):
         fn = next(filename_gen)
-        with pytest.warns(PlotNineWarning) as record:
+        with pytest.warns(PlotnineWarning) as record:
             p.save(fn)
 
         assert_exist_and_clean(fn, "save method")

--- a/plotnine/tests/test_save_as_pdf_pages.py
+++ b/plotnine/tests/test_save_as_pdf_pages.py
@@ -6,7 +6,7 @@ import pytest
 from plotnine import ggplot, aes, geom_text, ggtitle, theme
 from plotnine.data import mtcars
 from plotnine.ggplot import save_as_pdf_pages
-from plotnine.exceptions import PlotnineError
+from plotnine.exceptions import PlotnineError, PlotNineWarning
 
 
 def p(N=3):

--- a/plotnine/tests/test_save_as_pdf_pages.py
+++ b/plotnine/tests/test_save_as_pdf_pages.py
@@ -6,7 +6,7 @@ import pytest
 from plotnine import ggplot, aes, geom_text, ggtitle, theme
 from plotnine.data import mtcars
 from plotnine.ggplot import save_as_pdf_pages
-from plotnine.exceptions import PlotnineError, PlotNineWarning
+from plotnine.exceptions import PlotnineError, PlotnineWarning
 
 
 def p(N=3):

--- a/plotnine/tests/test_save_as_pdf_pages.py
+++ b/plotnine/tests/test_save_as_pdf_pages.py
@@ -6,7 +6,7 @@ import pytest
 from plotnine import ggplot, aes, geom_text, ggtitle, theme
 from plotnine.data import mtcars
 from plotnine.ggplot import save_as_pdf_pages
-from plotnine.exceptions import PlotnineError, PlotnineWarning
+from plotnine.exceptions import PlotnineError
 
 
 def p(N=3):

--- a/plotnine/tests/test_scale_internals.py
+++ b/plotnine/tests/test_scale_internals.py
@@ -22,7 +22,7 @@ from plotnine.scales.scale_size import (scale_size_discrete,
                                         scale_size_radius)
 from plotnine.scales.scale_manual import _scale_manual
 from plotnine.scales.scales import make_scale
-from plotnine.exceptions import PlotnineError
+from plotnine.exceptions import PlotnineError, PlotNineWarning
 
 _theme = theme(subplots_adjust={'right': 0.85})
 
@@ -60,7 +60,7 @@ def test_discrete_color_palettes():
     _assert_all_colors(colors, 9)
 
     s = sc.scale_color_brewer(type='seq')
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # upstream warning
         colors = s.palette(15)
     _assert_all_colors(colors, 9, 6)
 
@@ -74,7 +74,7 @@ def test_discrete_color_palettes():
     _assert_all_colors(colors, 11)
 
     s = sc.scale_color_brewer(type='div')
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # upstream warning
         colors = s.palette(21)
     _assert_all_colors(colors, 11, 10)
 
@@ -84,12 +84,12 @@ def test_discrete_color_palettes():
     _assert_all_colors(colors, 5)
 
     s = sc.scale_color_brewer(type='qual', palette='Accent')
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # upstream warning
         colors = s.palette(12)
     _assert_all_colors(colors, 8, 4)
 
     s = sc.scale_color_brewer(type='qual', palette='Set3')
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):  # upstream warning
         colors = s.palette(15)
     _assert_all_colors(colors, 12, 3)
 
@@ -131,7 +131,7 @@ def test_continuous_color_palettes():
     s = sc.scale_color_distiller(type='div')
     _assert(s)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(PlotNineWarning):
         s = sc.scale_color_distiller(type='qual')
     _assert(s)
 
@@ -215,7 +215,7 @@ def test_scale_manual():
         s = _scale(values)
         assert s.palette(2) == values
         assert s.palette(len(values)) == values
-        with pytest.warns(UserWarning):
+        with pytest.warns(PlotNineWarning):
             s.palette(len(values)+1)
 
     values = {'A': 'red', 'B': 'violet', 'C': 'blue'}
@@ -390,7 +390,7 @@ def test_scale_without_a_mapping():
     p = (ggplot(df, aes('x', 'x'))
          + geom_point()
          + scale_color.scale_color_continuous())
-    with pytest.warns(UserWarning):
+    with pytest.warns(PlotNineWarning):
         p.draw_test()
 
 

--- a/plotnine/tests/test_scale_internals.py
+++ b/plotnine/tests/test_scale_internals.py
@@ -22,7 +22,7 @@ from plotnine.scales.scale_size import (scale_size_discrete,
                                         scale_size_radius)
 from plotnine.scales.scale_manual import _scale_manual
 from plotnine.scales.scales import make_scale
-from plotnine.exceptions import PlotnineError, PlotNineWarning
+from plotnine.exceptions import PlotnineError, PlotnineWarning
 
 _theme = theme(subplots_adjust={'right': 0.85})
 
@@ -131,7 +131,7 @@ def test_continuous_color_palettes():
     s = sc.scale_color_distiller(type='div')
     _assert(s)
 
-    with pytest.warns(PlotNineWarning):
+    with pytest.warns(PlotnineWarning):
         s = sc.scale_color_distiller(type='qual')
     _assert(s)
 
@@ -215,7 +215,7 @@ def test_scale_manual():
         s = _scale(values)
         assert s.palette(2) == values
         assert s.palette(len(values)) == values
-        with pytest.warns(PlotNineWarning):
+        with pytest.warns(PlotnineWarning):
             s.palette(len(values)+1)
 
     values = {'A': 'red', 'B': 'violet', 'C': 'blue'}
@@ -390,7 +390,7 @@ def test_scale_without_a_mapping():
     p = (ggplot(df, aes('x', 'x'))
          + geom_point()
          + scale_color.scale_color_continuous())
-    with pytest.warns(PlotNineWarning):
+    with pytest.warns(PlotnineWarning):
         p.draw_test()
 
 

--- a/plotnine/tests/test_stat.py
+++ b/plotnine/tests/test_stat.py
@@ -5,7 +5,7 @@ from plotnine import ggplot, aes, geom_bar
 from plotnine.data import mtcars
 from plotnine.geoms.geom import geom
 from plotnine.stats.stat import stat
-from plotnine.exceptions import PlotnineError
+from plotnine.exceptions import PlotnineError, PlotNineWarning
 
 
 def test_stat_basics():
@@ -76,7 +76,7 @@ def test_removes_infinite_values():
     df.loc[[0, 5], 'wt'] = [np.inf, -np.inf]
     p = ggplot(df, aes(x='wt')) + geom_bar()
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(PlotNineWarning) as record:
         p._build()
 
     def removed_2_row_with_infinites(record):

--- a/plotnine/tests/test_stat.py
+++ b/plotnine/tests/test_stat.py
@@ -5,7 +5,7 @@ from plotnine import ggplot, aes, geom_bar
 from plotnine.data import mtcars
 from plotnine.geoms.geom import geom
 from plotnine.stats.stat import stat
-from plotnine.exceptions import PlotnineError, PlotNineWarning
+from plotnine.exceptions import PlotnineError, PlotnineWarning
 
 
 def test_stat_basics():
@@ -76,7 +76,7 @@ def test_removes_infinite_values():
     df.loc[[0, 5], 'wt'] = [np.inf, -np.inf]
     p = ggplot(df, aes(x='wt')) + geom_bar()
 
-    with pytest.warns(PlotNineWarning) as record:
+    with pytest.warns(PlotnineWarning) as record:
         p._build()
 
     def removed_2_row_with_infinites(record):

--- a/plotnine/utils.py
+++ b/plotnine/utils.py
@@ -19,7 +19,7 @@ from matplotlib.patches import Rectangle
 from mizani.bounds import zero_range
 from mizani.utils import multitype_sort
 
-from .exceptions import PlotnineError
+from .exceptions import PlotnineError, PlotNineWarning
 
 
 # Points and lines of equal size should give the
@@ -520,7 +520,7 @@ def remove_missing(df, na_rm=False, vars=None, name='', finite=False):
     df.reset_index(drop=True, inplace=True)
     if len(df) < n and not na_rm:
         msg = '{} : Removed {} rows containing {} values.'
-        warn(msg.format(name, n-len(df), txt), stacklevel=3)
+        warn(msg.format(name, n-len(df), txt), PlotNineWarning, stacklevel=3)
     return df
 
 

--- a/plotnine/utils.py
+++ b/plotnine/utils.py
@@ -19,7 +19,7 @@ from matplotlib.patches import Rectangle
 from mizani.bounds import zero_range
 from mizani.utils import multitype_sort
 
-from .exceptions import PlotnineError, PlotNineWarning
+from .exceptions import PlotnineError, PlotnineWarning
 
 
 # Points and lines of equal size should give the
@@ -520,7 +520,7 @@ def remove_missing(df, na_rm=False, vars=None, name='', finite=False):
     df.reset_index(drop=True, inplace=True)
     if len(df) < n and not na_rm:
         msg = '{} : Removed {} rows containing {} values.'
-        warn(msg.format(name, n-len(df), txt), PlotNineWarning, stacklevel=3)
+        warn(msg.format(name, n-len(df), txt), PlotnineWarning, stacklevel=3)
     return df
 
 

--- a/plotnine/utils.py
+++ b/plotnine/utils.py
@@ -284,10 +284,10 @@ def ninteraction(df, drop=False):
         return len(np.unique(x))
     ndistinct = ids.apply(len_unique, axis=0).values
 
-    combs = np.matrix(
+    combs = np.array(
         np.hstack([1, np.cumprod(ndistinct[:-1])]))
-    mat = np.matrix(ids)
-    res = (mat - 1) * combs.T + 1
+    mat = np.array(ids)
+    res = (mat - 1) @ combs.T + 1
     res = np.array(res).flatten().tolist()
 
     if drop:


### PR DESCRIPTION
This PR introduces a new Warning class PlotNineWarning,
which is now used throughout the plotnine code base when emitting warnings

It allows the downstream to capture PlotNine warnings in a structured way.

Note that PlotNine will still emit UserWarnings from upstream  - they are not being rewritten.

I've also promoted PlotNineException and PlotNineWarning to top-level objects on 
the module, so they're visible to the user.

