### PR TITLE
input validation on geom_violin(draw_quantiles)

### DIFF
--- a/plotnine/geoms/geom_violin.py
+++ b/plotnine/geoms/geom_violin.py
@@ -19,6 +19,9 @@ class geom_violin(geom):
     Parameters
     ----------
     {common_parameters}
+    draw_quantiles: float or [float]
+       draw horizontal lines at the given quantiles (0..1)
+       of the density estimate.
     """
     DEFAULT_AES = {'alpha': 1, 'color': '#333333', 'fill': 'white',
                    'linetype': 'solid', 'size': 0.5, 'weight': 1}
@@ -27,6 +30,17 @@ class geom_violin(geom):
                       'draw_quantiles': None, 'scale': 'area',
                       'trim': True, 'width': None, 'na_rm': False}
     legend_geom = 'polygon'
+
+    def __init__(self, *args, **kwargs):
+        if 'draw_quantiles' in kwargs:
+            kwargs['draw_quantiles'] = pd.Series(kwargs['draw_quantiles'],
+                                                 dtype=float)
+            if not kwargs['draw_quantiles'].between(0, 1,
+                                                    inclusive=False).all():
+                raise ValueError(
+                    "draw_quantiles must be a float or"
+                    " an iterable of floats (>0.0; < 1.0)")
+        super().__init__(*args, **kwargs)
 
     def setup_data(self, data):
         if 'width' not in data:
@@ -76,7 +90,7 @@ class geom_violin(geom):
             geom_polygon.draw_group(polygon_df, panel_params,
                                     coord, ax, **params)
 
-            if quantiles:
+            if quantiles is not None:
                 # Get dataframe with quantile segments and that
                 # with aesthetics then put them together
                 # Each quantile segment is defined by 2 points and

--- a/plotnine/tests/test_geom_violin.py
+++ b/plotnine/tests/test_geom_violin.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from plotnine import ggplot, aes, geom_violin, coord_flip, theme
 
@@ -56,6 +57,23 @@ def test_quantiles_width_dodge():
                      size=2) +
          theme(subplots_adjust={'right': 0.85}))
     assert p == 'quantiles_width_dodge'
+
+
+def test_quantiles_input_checks():
+    with pytest.raises(ValueError):
+        geom_violin(aes('x', 'y'), draw_quantiles=True)
+    with pytest.raises(ValueError):
+        geom_violin(aes('x', 'y'), draw_quantiles=["A", 0.25])
+    with pytest.raises(ValueError):
+        geom_violin(aes('x', 'y'), draw_quantiles=[0.25, 1.25])
+    with pytest.raises(ValueError):
+        geom_violin(aes('x', 'y'), draw_quantiles=[0.])
+    with pytest.raises(ValueError):
+        geom_violin(aes('x', 'y'), draw_quantiles=[1.])
+    g = geom_violin(aes('x', 'y'), draw_quantiles=np.array([0.25, 0.25]))
+    assert isinstance(g.params['draw_quantiles'], pd.Series)
+    g = geom_violin(aes('x', 'y'), draw_quantiles=0.5)
+    assert isinstance(g.params['draw_quantiles'], pd.Series)
 
 
 def test_no_trim():


### PR DESCRIPTION
This PR checks, normalizes and documents the draw_quantiles parameter on geom_violin.

It now accepts any iterable of floats, or a single float (to be feature compatible with ggplot2).
They get converted into a list internally.

If it's not valid (ie. not float, [float] or values outside of 0..1 (exclusive), a ValueError is raised
when calling geom_violin.

Previously, the following happened:
 * draw_quantiles = True -> Exception in drawing  ```TypeError: object of type 'bool' has no len()``` 
 * draw_quantiles = 0.5 -> Exception in drawing: ```TypeError: object of type 'float' has no len()```
 * draw_quantiles = np.array([0.5]) -> ok
 * draw_quantiles = np.array([0.3, 0.5]) -> exception in drawing: ```ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()```
* draw_quantiles = 0 -> interpreted as False
* draw_quantiles = [0.0] -> exception in drawing: ```ValueError: A value in x_new is below the interpolation range.```
* draw_quantiles = [1.0] -> exception in drawing: ```ValueError: A value in x_new is above the interpolation range.```
* draw_quantiles = [1.25] -> exception in drawing: ```ValueError: A value in x_new is above the interpolation range.```

These all now either work, or throw a sensible exception ```ValueError("draw_quantiles must be a float or an iterable of floats (>0.0; < 1.0)")``` much closer to the actual erroneous call.


