### PR TITLE
Add library imports to documentation homepage

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,9 @@ simple plots remain simple.
 Example
 -------
 .. code:: python
-
+    from plotnine import *
+    from plotnine.data import mtcars
+    
     (ggplot(mtcars, aes('wt', 'mpg', color='factor(gear)'))
      + geom_point()
      + stat_smooth(method='lm')


### PR DESCRIPTION
👋  As a new user, I tried to run the code example to generate the provided `mtcars` plot. However, I didn't know what to import to get all the functions loaded and the `mtcars` dataset. Adding

```
from plotnine import *
from plotnine.data import mtcars
```

can help new users try out the library without seeking any further docs or examples. 