### PR TITLE
stats check for unknown arguments when used in a geom

### DIFF
--- a/plotnine/geoms/geom.py
+++ b/plotnine/geoms/geom.py
@@ -359,7 +359,8 @@ class geom(metaclass=Registry):
         """
         Verify arguments passed to the geom
         """
-        unknown = (kwargs.keys() -
+        geom_stat_args = kwargs.keys() | self._stat._kwargs.keys()
+        unknown = (geom_stat_args -
                    self.aesthetics() -                # geom aesthetics
                    self.DEFAULT_PARAMS.keys() -        # geom parameters
                    self._stat.aesthetics() -          # stat aesthetics

--- a/plotnine/tests/test_stat_summary.py
+++ b/plotnine/tests/test_stat_summary.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pandas as pd
+import pytest
 
-from plotnine import ggplot, aes, stat_summary
+from plotnine import ggplot, aes, stat_summary, geom_point
+from plotnine.exceptions import PlotnineError
 
 
 random_state = np.random.RandomState(1234567890)
@@ -66,3 +68,10 @@ def test_summary_functions():
                         size=2))
 
     assert p == 'summary_functions'
+
+
+def test_stat_summary_raises_on_invalid_paremeters():
+    with pytest.raises(PlotnineError):
+        geom_point(stat_summary(funy=np.mean))
+    with pytest.raises(PlotnineError):
+        geom_point(stat_summary(does_not_exist=1))


### PR DESCRIPTION
Bug
```python
g += geom_point(aes('group','y', color='group'),
                stat = stat_summary(funy=np.mean),                
               )```
Did not raise an exception (note misspelling of fun_y).

```
g += geom_point(aes('group','y', color='group'),
                stat = stat_summary(),                
                funy=np.mean
               )
```
does though.

This extends the geoms error checking to also check the stat's arguments.
We can't do it in the stat.__init__ since it is ok to pass geom arguments here,
for example if using the stat as a standalone layer, so we have to do it in the geom's verify_arguments.
