### PR TITLE
fix: annotation_logticks & any discrete scale

### DIFF
--- a/plotnine/geoms/annotation_logticks.py
+++ b/plotnine/geoms/annotation_logticks.py
@@ -47,21 +47,27 @@ class _geom_logticks(geom_rug):
         out : tuple
             The bases (base_x, base_y) to use when generating the ticks.
         """
-        def is_log(trans):
+        def is_log(scale):
+            if not hasattr(scale, 'trans'):
+                return False
+            trans = scale.trans
             return (trans.__class__.__name__.startswith('log') and
                     hasattr(trans, 'base'))
 
         base_x, base_y = base, base
         x_scale = panel_params.x.scale
         y_scale = panel_params.y.scale
-        x_is_log = is_log(x_scale.trans)
-        y_is_log = is_log(y_scale.trans)
+        x_is_log = is_log(x_scale)
+        y_is_log = is_log(y_scale)
         if isinstance(coord, coord_flip):
             x_is_log, y_is_log = y_is_log, x_is_log
 
         if 't' in sides or 'b' in sides:
             if base_x is None:
-                base_x = x_scale.trans.base
+                if x_is_log:
+                    base_x = x_scale.trans.base
+                else:  # no log, no defined base. See warning below.
+                    base_x = 10
 
             if not x_is_log:
                 warnings.warn(
@@ -77,7 +83,10 @@ class _geom_logticks(geom_rug):
 
         if 'l' in sides or 'r' in sides:
             if base_y is None:
-                base_y = y_scale.trans.base
+                if y_is_log:
+                    base_y = y_scale.trans.base
+                else:  # no log, no defined base. See warning below.
+                    base_y = 10
 
             if not y_is_log:
                 warnings.warn(

--- a/plotnine/tests/test_annotation_logticks.py
+++ b/plotnine/tests/test_annotation_logticks.py
@@ -95,3 +95,23 @@ def test_wrong_bases():
 
     with pytest.warns(PlotnineWarning):
         p.draw_test()
+
+    # x axis is discrete
+    df2 = df.assign(discrete=pd.Categorical([str(a) for a in df['x']]))
+    p = (ggplot(df2, aes('discrete', 'x'))
+         + annotation_logticks(sides='b', size=.75, base=None)
+         + geom_point()
+         )
+
+    with pytest.warns(PlotnineWarning):
+        p.draw_test()
+
+    # y axis is discrete
+    df2 = df.assign(discrete=pd.Categorical([str(a) for a in df['x']]))
+    p = (ggplot(df2, aes('x', 'discrete'))
+         + annotation_logticks(sides='l', size=.75, base=None)
+         + geom_point()
+         )
+
+    with pytest.warns(PlotnineWarning):
+        p.draw_test()


### PR DESCRIPTION
Adding annotation_logticks to a plot with a discrete scale fails with an exception:
```python
/project/code/plotnine/plotnine/geoms/annotation_logticks.py in _check_log_scale(base, sides, panel_params, coord)
     55         x_scale = panel_params.x.scale
     56         y_scale = panel_params.y.scale
---> 57         x_is_log = is_log(x_scale.trans)
     58         y_is_log = is_log(y_scale.trans)
     59         if isinstance(coord, coord_flip):

AttributeError: 'scale_x_discrete' object has no attribute 'trans'
```

This is independent of the sides argument.

This PR simply adds a check for the scale having a .trans attribute in is_log, and later on, if the base has not been set by the user (we didn't test for this combination of non-log axis and no base specified), 
default to base 10 (arbitrary, but we're in 'warning, your scale in not log'-territory anyway).