### PR TITLE
fix: IndexError if values exceeded scale_discrete palette size

### DIFF
--- a/plotnine/scales/scale.py
+++ b/plotnine/scales/scale.py
@@ -432,14 +432,9 @@ class scale_discrete(scale):
             except IndexError:
                 # Deal with missing data
                 # - Insert NaN where there is no match
-                bool_idx_good = (0 <= idx) & (idx < len(pal))
-                bool_idx_bad = ~bool_idx_good
-                pal_match = pal[idx[bool_idx_good]]
-                pal_match = np.insert(
-                    np.array(pal_match, dtype=object),
-                    np.where(bool_idx_bad)[0],
-                    np.nan
-                )
+                pal = np.hstack((pal.astype(object), np.nan))
+                idx = np.clip(idx, 0, len(pal)-1)
+                pal_match = pal[idx]
 
         if self.na_translate:
             bool_idx = pd.isnull(x) | pd.isnull(pal_match)

--- a/plotnine/tests/test_scale_internals.py
+++ b/plotnine/tests/test_scale_internals.py
@@ -7,7 +7,7 @@ import pytest
 
 from plotnine import ggplot, aes, geom_point, expand_limits, theme
 from plotnine import geom_col, lims, element_text, annotate
-from plotnine.scales import scale_color
+from plotnine.scales import scale_color, scale_color_manual
 from plotnine.scales import scale_identity
 from plotnine.scales import scale_manual
 from plotnine.scales import scale_xy
@@ -645,3 +645,16 @@ def test_layer_with_only_infs():
          )
     p = p.build_test()
     assert isinstance(p.scales.get_scales('x'), scale_x_discrete)
+
+
+def test_discrete_scale_exceeding_maximum_number_of_values():
+    df = pd.DataFrame({
+        # not that it's the second c that triggered a bug in scale_discrete.map
+        'x': pd.Categorical(['c', 'a', 'c', 'b', 'c']),
+        'y': [0, 1, 2, 2, 3]})
+    p = (ggplot(df, aes('x', 'y', color='x', shape='x'))
+         + geom_point()
+         + scale_color_manual(['red', 'blue'])
+         )
+    with pytest.warns(PlotnineWarning):
+        p.draw()


### PR DESCRIPTION
This plot would fail with an IndexError in map (and not just a warning for omitted values due to palette limits):

```python
  df = pd.DataFrame({
        # not that it's the second c that triggered a bug in scale_discrete.map
        'x': pd.Categorical(['a', 'b', 'c', 'c']),
        'y': [0, 1, 2, 2]})
    p = (ggplot(df, aes('x', 'y', color='x', shape='x'))
         + geom_jitter()
         + scale_color_manual(['red', 'blue'])
         ).save('test.png')
```

This PR fixes it by replacing a complicated numpy 'insert NaNs at indices' solution with a call to pandas.Series.reindex() which helpfully replaces non-existent indices with the NaNs we need.