### PR TITLE
QoL: Flake8 test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
         apt:
           packages:
           - pandoc
+    - python: 3.7
+      env:
+        - JOB: 'LINT'
+        - FULL_DEPS: false
 
 cache: pip
 
@@ -60,9 +64,10 @@ install:
       conda install pytest-cov
       conda install -c conda-forge "pyshp>=2.0.0" # temporary
       pip install coveralls
-      pip install flake8
     elif [[ "$JOB" == "DOCS" ]]; then
       pip install -r requirements/doc.txt
+    elif [[ "$JOB" == "LINT" ]]; then
+      pip install flake8
     fi
   # List all conda and pip packages
   - conda list
@@ -79,6 +84,8 @@ script:
       # low pandoc version leads to a warning so
       # SPHINXOPTS=-W fails
       make html && popd
+    elif [[ "$JOB" == "LINT" ]]; then
+      make lint
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ matrix:
         apt:
           packages:
           - pandoc
-    - python: 3.7
-      env:
-        - JOB: 'LINT'
-        - FULL_DEPS: false
 
 cache: pip
 
@@ -64,10 +60,9 @@ install:
       conda install pytest-cov
       conda install -c conda-forge "pyshp>=2.0.0" # temporary
       pip install coveralls
+      pip install flake8
     elif [[ "$JOB" == "DOCS" ]]; then
       pip install -r requirements/doc.txt
-    elif [[ "$JOB" == "LINT" ]]; then
-      pip install flake8
     fi
   # List all conda and pip packages
   - conda list
@@ -84,8 +79,6 @@ script:
       # low pandoc version leads to a warning so
       # SPHINXOPTS=-W fails
       make html && popd
-    elif [[ "$JOB" == "LINT" ]]; then
-      make lint
     fi
 
 

--- a/plotnine/tests/test_flake8.py
+++ b/plotnine/tests/test_flake8.py
@@ -1,0 +1,20 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+file_dir = Path(__file__).parent
+
+
+class Flake8TestCase(unittest.TestCase):
+    def test_flake8(self):
+        p = subprocess.Popen(
+            ["flake8", str((file_dir.parent).absolute())],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = p.communicate()
+        if p.returncode != 0:
+            self.fail(
+                "Flake 8 found issues: %s\n%s"
+                % (stdout.decode("utf-8"), stderr.decode("utf-8"))
+            )

--- a/plotnine/tests/test_flake8.py
+++ b/plotnine/tests/test_flake8.py
@@ -1,20 +1,20 @@
+import os
 import subprocess
-import unittest
 from pathlib import Path
 
-file_dir = Path(__file__).parent
 
-
-class Flake8TestCase(unittest.TestCase):
-    def test_flake8(self):
+if not os.environ.get('TRAVIS'):
+    def test_flake8():
+        plotnine_dir = str(Path(__file__).parent.parent.absolute())
         p = subprocess.Popen(
-            ["flake8", str((file_dir.parent).absolute())],
+            ['flake8', plotnine_dir],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        stdout, stderr = p.communicate()
-        if p.returncode != 0:
-            self.fail(
-                "Flake 8 found issues: %s\n%s"
-                % (stdout.decode("utf-8"), stderr.decode("utf-8"))
-            )
+        # Ignore the stderr msg as it is mostly noise
+        # about coverage warnings
+        stdout, _ = p.communicate()
+        msg = "flake8 found the following issues: \n\n{}".format(
+                 stdout.decode('utf-8')
+        )
+        assert p.returncode == 0, msg


### PR DESCRIPTION
Replaces the Travis based flake8 linting
with a pytest test case. This eases the burden
on contributers to remember running flake8 before
submitting a PR and should speed up the travis runs a bit.

(This is just a tiny quality of life change for me)