### PR TITLE
Turn ha and va into aesthetics for geom_text()

### DIFF
--- a/plotnine/geoms/geom_text.py
+++ b/plotnine/geoms/geom_text.py
@@ -38,10 +38,6 @@ class geom_text(geom):
         Font weight.
     fontstyle : str (default: normal)
         Font style. One of *normal*, *italic* or *oblique*
-    ha : str (default: center)
-        Horizontal alignment. One of *left*, *center* or *right.*
-    va : str (default: center)
-        Vertical alignment. One of *top*, *center* or *bottom.*
     nudge_x : float (default: 0)
         Horizontal adjustment to apply to the text
     nudge_y : float (default: 0)
@@ -61,13 +57,13 @@ class geom_text(geom):
 
     """
     DEFAULT_AES = {'alpha': 1, 'angle': 0, 'color': 'black',
-                   'size': 11, 'lineheight': 1.2}
+                   'size': 11, 'lineheight': 1.2, 'ha': 'center',
+                   'va': 'center'}
     REQUIRED_AES = {'label', 'x', 'y'}
     DEFAULT_PARAMS = {'stat': 'identity', 'position': 'identity',
                       'na_rm': False, 'parse': False,
                       'family': None, 'fontweight': 'normal',
-                      'fontstyle': 'normal', 'ha': 'center',
-                      'va': 'center', 'nudge_x': 0, 'nudge_y': 0,
+                      'fontstyle': 'normal', 'nudge_x': 0, 'nudge_y': 0,
                       'adjust_text': None,
                       'format_string': None}
 
@@ -86,13 +82,6 @@ class geom_text(geom):
                 "To use adjust_text you must install the adjustText "
                 "package."
             )
-
-        # Accomodate for the old names
-        if 'hjust' in kwargs:
-            kwargs['ha'] = kwargs.pop('hjust')
-
-        if 'vjust' in kwargs:
-            kwargs['va'] = kwargs.pop('vjust')
 
         geom.__init__(self, mapping, data, **kwargs)
 
@@ -127,8 +116,8 @@ class geom_text(geom):
         df['rotation'] = data['angle']
         df['linespacing'] = data['lineheight']
         df['color'] = color
-        df['ha'] = params['ha']
-        df['va'] = params['va']
+        df['ha'] = data['ha']
+        df['va'] = data['va']
         df['family'] = params['family']
         df['fontweight'] = params['fontweight']
         df['fontstyle'] = params['fontstyle']


### PR DESCRIPTION
While recreating the following figure of [Section 28.3 from R for Data Science](https://r4ds.had.co.nz/graphics-for-communication.html#annotations):

![](https://d33wubrfki0l68.cloudfront.net/5d5bd93e3646741c7be240b87833d5f22aa558ea/f91c0/communicate-plots_files/figure-html/just-1.png)

I noticed that `ha` and `va` are not aesthetics but parameters. According to the documentation, this is because of a limitation in Matplotlib (see https://github.com/matplotlib/matplotlib/pull/1181). Unless I fail to fully understand the issue, I believe that this small change fixes it. At least I was able to reproduce the above figure with the following code:

```python
from plotnine import *
import pandas as pd
from itertools import product

has = ["left", "center", "right"]
vas = ["top", "center", "bottom"]
xs = [0, 0.5, 1]
ys = [1, 0.5, 0]

df = pd.DataFrame([{"x": xs[x],
                    "y": ys[y],
                    "ha": has[x],
                    "va": vas[y],
                    "label": f"ha=\"{has[x]}\"\nva=\"{vas[y]}\""}
                   for x, y in product(range(3), repeat=2)])

ggplot(df, aes("x", "y")) +\
geom_point(colour="grey", size=5) +\
geom_point(size=0.5, colour="red") +\
geom_text(aes(label="label", ha="ha", va="va"), size=14) +\
labs(x=None, y=None)
```

![download (4)](https://user-images.githubusercontent.com/1368256/67182478-9c79df00-f3df-11e9-960f-4eba8b8ece1d.png)

Please forgive me for not yet taking care of the deprecated terms "hjust" and "vjust". I wasn't able to quickly figure out how to treat those as aliases in the case of aesthetics.