### PR TITLE
Fix rename_aesthetics for Python3.8

### DIFF
--- a/plotnine/aes.py
+++ b/plotnine/aes.py
@@ -177,7 +177,7 @@ def rename_aesthetics(obj):
         Object that contains aesthetics names
     """
     if isinstance(obj, dict):
-        for name in obj:
+        for name in tuple(obj.keys()):
             new_name = name.replace('colour', 'color')
             if name != new_name:
                 obj[new_name] = obj.pop(name)


### PR DESCRIPTION
Thank you for this great library.

In Python3.8, we cannot pop a key from a dict when iterating it.
```python
In [1]: d = {"key": 0}                                                                                                                                                                                              

In [2]: for name in d: 
   ...:     d["new-key"] = d.pop(name) 
   ...:                                                                                                                                                                                                             
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-3ee45a753e90> in <module>
----> 1 for name in d:
      2     d["new-key"] = d.pop(name)
      3 

RuntimeError: dictionary keys changed during iteration
```

(Maybe it is because of https://github.com/python/cpython/pull/12596, but I'm not sure.)

So this PR fixes this kind of invalid mutation in 'rename_aethestics', by using `tuple`.