### PR TITLE
fix labels with aes(x=(not a string))

### DIFF
--- a/plotnine/aes.py
+++ b/plotnine/aes.py
@@ -1,6 +1,7 @@
 import re
 from copy import deepcopy
 from contextlib import suppress
+from collections.abc import Iterable
 
 import numpy as np
 import pandas as pd
@@ -371,14 +372,24 @@ def is_position_aes(vars_):
         return aes_to_scale(vars_) in {'x', 'y'}
 
 
+def _make_label(ae, label):
+    if isinstance(label, pd.Series):
+        return label.name
+    # if label is a scalar
+    elif not isinstance(label, Iterable) or isinstance(label, str):
+        return strip_calculated_markers(str(label))
+    else:
+        return None
+
+
 def make_labels(mapping):
     """
     Convert aesthetic mapping into text labels
     """
-    labels = mapping.copy()
-    for ae in labels:
-        labels[ae] = strip_calculated_markers(labels[ae])
-    return labels
+    return {
+        ae: _make_label(ae, label)
+        for ae, label in mapping.items()
+    }
 
 
 def is_valid_aesthetic(value, ae):

--- a/plotnine/aes.py
+++ b/plotnine/aes.py
@@ -372,20 +372,20 @@ def is_position_aes(vars_):
         return aes_to_scale(vars_) in {'x', 'y'}
 
 
-def _make_label(ae, label):
-    if isinstance(label, pd.Series):
-        return label.name
-    # if label is a scalar
-    elif not isinstance(label, Iterable) or isinstance(label, str):
-        return strip_calculated_markers(str(label))
-    else:
-        return None
-
-
 def make_labels(mapping):
     """
     Convert aesthetic mapping into text labels
     """
+
+    def _make_label(ae, label):
+        if isinstance(label, pd.Series):
+            return label.name
+        # if label is a scalar
+        elif not isinstance(label, Iterable) or isinstance(label, str):
+            return strip_calculated_markers(str(label))
+        else:
+            return None
+
     return {
         ae: _make_label(ae, label)
         for ae, label in mapping.items()

--- a/plotnine/tests/test_aes.py
+++ b/plotnine/tests/test_aes.py
@@ -38,7 +38,7 @@ def test_labels_series():
 
 def test_labels_lists():
     p = (
-        ggplot(df, aes(x=[1,2,3], y=[1,2,3]))
+        ggplot(df, aes(x=[1, 2, 3], y=[1, 2, 3]))
         + geom_col()
     )
     assert p.labels == {'x': None, 'y': None}

--- a/plotnine/tests/test_aes.py
+++ b/plotnine/tests/test_aes.py
@@ -26,3 +26,19 @@ def test_reorder_index():
         + geom_col()
     )
     assert p + _theme == 'reorder_index'
+
+
+def test_labels_series():
+    p = (
+        ggplot(df, aes(x=df.x, y=df.y))
+        + geom_col()
+    )
+    assert p.labels == {'x': 'x', 'y': 'y'}
+
+
+def test_labels_lists():
+    p = (
+        ggplot(df, aes(x=[1,2,3], y=[1,2,3]))
+        + geom_col()
+    )
+    assert p.labels == {'x': None, 'y': None}


### PR DESCRIPTION
Currently passing a non-string to an aesthetic can cause crashes in matplotlib, as the aesthetic value gets passed directly as the label, which matplotlib wants a string for.
E.g. if you pass a pd.Series, you'll get a crash, because matplotlib calls `==` on it:
```py

def tuplify(df):
	return df.apply(tuple, axis='columns').rename(str(tuple(df.columns))).pipe(peep)

(
	ggplot(
		toPlot,
		aes(
			x=toPlot[['Bin', 'Year']].pipe(tuplify),
			y='value',
			fill='Statistic',
		)
	)
	+ geom_col(stat='identity', position='dodge')
).draw()
```
```
~/src/ow/fa/analyses/massbuy/.venv/lib/python3.6/site-packages/matplotlib/text.py in set_text(self, s)
   1163         if s is None:
   1164             s = ''
-> 1165         if s != self._text:
   1166             self._text = str(s)
   1167             self.stale = True

~/src/ow/fa/analyses/massbuy/.venv/lib/python3.6/site-packages/pandas/core/generic.py in __nonzero__(self)
   1477     def __nonzero__(self):
   1478         raise ValueError(
-> 1479             f"The truth value of a {type(self).__name__} is ambiguous. "
   1480             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
   1481         )

ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

This patch makes sure labels are always set to strings.

In the case where a label cannot be determined, it gets set to None, and the axis/legend/etc. will be blank. R in this case uses the variable name, which we do not have access to.