### PR TITLE
fix aes argument typehint according to PEP0484

### DIFF
--- a/plotnine/aes.py
+++ b/plotnine/aes.py
@@ -38,7 +38,7 @@ class aes(dict):
         x aesthetic mapping
     y : expression | array_like | scalar
         y aesthetic mapping
-    **kwargs : dict
+    **kwargs : str
         Other aesthetic mappings
 
     Notes


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values