### PR TITLE
Set the font family in `rcParams` as default for some themes

### DIFF
--- a/plotnine/themes/theme_538.py
+++ b/plotnine/themes/theme_538.py
@@ -16,7 +16,7 @@ class theme_538(theme_gray):
     base_family : str, optional
         Base font family.
     """
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         theme_gray.__init__(self, base_size, base_family)
         bgcolor = '#F0F0F0'
         self.add_theme(

--- a/plotnine/themes/theme_bw.py
+++ b/plotnine/themes/theme_bw.py
@@ -16,7 +16,7 @@ class theme_bw(theme_gray):
         Base font family.
     """
 
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         theme_gray.__init__(self, base_size, base_family)
         self.add_theme(
             theme(axis_text=element_text(size=0.8*base_size),

--- a/plotnine/themes/theme_classic.py
+++ b/plotnine/themes/theme_classic.py
@@ -17,7 +17,7 @@ class theme_classic(theme_bw):
         Base font family.
     """
 
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         theme_bw.__init__(self, base_size, base_family)
         self.add_theme(
             theme(panel_border=element_blank(),

--- a/plotnine/themes/theme_dark.py
+++ b/plotnine/themes/theme_dark.py
@@ -18,7 +18,7 @@ class theme_dark(theme_gray):
         Base font family.
     """
 
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         theme_gray.__init__(self, base_size, base_family)
         self.add_theme(theme(
             axis_ticks=element_line(color='#666666', size=0.5),

--- a/plotnine/themes/theme_gray.py
+++ b/plotnine/themes/theme_gray.py
@@ -19,7 +19,7 @@ class theme_gray(theme):
     base_family : str, optional
         Base font family.
     """
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         half_line = base_size/2
         # super does not work well with reloads
         theme.__init__(

--- a/plotnine/themes/theme_light.py
+++ b/plotnine/themes/theme_light.py
@@ -17,7 +17,7 @@ class theme_light(theme_gray):
         Base font family.
     """
 
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         theme_gray.__init__(self, base_size, base_family)
         self.add_theme(theme(
             axis_ticks=element_line(color='#B3B3B3', size=0.5),

--- a/plotnine/themes/theme_linedraw.py
+++ b/plotnine/themes/theme_linedraw.py
@@ -16,7 +16,7 @@ class theme_linedraw(theme_gray):
         Base font family.
     """
 
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         theme_gray.__init__(self, base_size, base_family)
         self.add_theme(theme(
             axis_text=element_text(color='black', size=base_size*0.8),

--- a/plotnine/themes/theme_minimal.py
+++ b/plotnine/themes/theme_minimal.py
@@ -16,7 +16,7 @@ class theme_minimal(theme_bw):
         Base font family.
     """
 
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         theme_bw.__init__(self, base_size, base_family)
         self.add_theme(
             theme(legend_background=element_blank(),

--- a/plotnine/themes/theme_void.py
+++ b/plotnine/themes/theme_void.py
@@ -17,7 +17,7 @@ class theme_void(theme):
         Base font family.
     """
 
-    def __init__(self, base_size=11, base_family='DejaVu Sans'):
+    def __init__(self, base_size=11, base_family=None):
         # Use only inherited elements and make everything blank
         theme.__init__(
             self,


### PR DESCRIPTION
Please refer to #436

Some themes' default font family is set as DejaVu Sans, which has large coverage for unicode -- Extended Latin, Cyrricil, Arabic, and so on. But this font doesn't cover CJK (Chinese, Japanese and Korean) fonts. So I propose changing the default value to `None`
