### PR TITLE
Handle change in domain check behaviour in statsmodels 0.12.

### DIFF
--- a/plotnine/stats/stat_density.py
+++ b/plotnine/stats/stat_density.py
@@ -185,6 +185,8 @@ def compute_density(x, weight, range, **params):
 
     try:
         y = kde.evaluate(x2)
+        if np.isscalar(y) and np.isnan(y):
+            raise ValueError('kde.evaluate returned nan')
     except ValueError:
         y = []
         for _x in x2:


### PR DESCRIPTION
statsmodels 0.12 fixed a bug where evaluating points outside of the
domain in density estimation now returns np.nan instead of raising a
ValueError. Detect both cases and fallback to estimating the density
point-wise.

Context: https://github.com/statsmodels/statsmodels/pull/6547