### PR TITLE
Update index.rst, fix ggplot2 website reference

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,4 +45,4 @@ Documentation
    glossary
    external-resources
 
-.. _ggplot2: http://ggplot2.org
+.. _ggplot2: https://ggplot2.tidyverse.org


### PR DESCRIPTION
It seems http://ggplot2.org/ is no longer available.