### PR TITLE
Fix normalization constant for bin counts

### DIFF
--- a/plotnine/stats/binning.py
+++ b/plotnine/stats/binning.py
@@ -201,7 +201,7 @@ def result_dataframe(count, x, width, xmin=None, xmax=None):
         'xmax': xmax,
         'width': width,
         'density': density,
-        'ncount': count/np.max(np.abs(count)),
+        'ncount': count/np.sum(np.abs(count)),
         'ndensity': count/np.max(np.abs(density)),
         'ngroup:': np.sum(np.abs(count))})
     return out


### PR DESCRIPTION
Normalization should compute the proportion of elements in each bin relative to the total number of elements, not the number of elements in the biggest bin.

Note: 'ndensity' also looks suspect, but I'm not sure what the intended behavior is there