### PR TITLE
Allow user to change relative width or height of facets

### DIFF
--- a/plotnine/facets/facet.py
+++ b/plotnine/facets/facet.py
@@ -91,7 +91,7 @@ class facet:
     def __init__(self, scales='fixed', shrink=True,
                  labeller='label_value', as_table=True,
                  drop=True, dir='h',
-                 height_ratios=None, 
+                 height_ratios=None,
                  width_ratios=None):
         from .labelling import as_labeller
         self.shrink = shrink

--- a/plotnine/facets/facet.py
+++ b/plotnine/facets/facet.py
@@ -15,7 +15,7 @@ from ..scales.scales import Scales
 # For default matplotlib backend
 with suppress(ImportError):
     from matplotlib.ticker import locale, FixedFormatter
-	from matplotlib.gridspec import GridSpec
+    from matplotlib.gridspec import GridSpec
 
 
 class facet:
@@ -91,8 +91,8 @@ class facet:
     def __init__(self, scales='fixed', shrink=True,
                  labeller='label_value', as_table=True,
                  drop=True, dir='h',
-				 height_ratios = None, 
-				 width_ratios = None):
+                 height_ratios = None, 
+                 width_ratios = None):
         from .labelling import as_labeller
         self.shrink = shrink
         self.labeller = as_labeller(labeller)

--- a/plotnine/facets/facet.py
+++ b/plotnine/facets/facet.py
@@ -15,6 +15,7 @@ from ..scales.scales import Scales
 # For default matplotlib backend
 with suppress(ImportError):
     from matplotlib.ticker import locale, FixedFormatter
+	from matplotlib.gridspec import GridSpec
 
 
 class facet:
@@ -47,6 +48,10 @@ class facet:
     dir : str in ``['h', 'v']``
         Direction in which to layout the panels. ``h`` for
         horizontal and ``v`` for vertical.
+    height_ratios: for example [2, 1]
+        list of heights (relative ratio) for each vertical row in facet
+    width_ratios: for example [1, 1]
+        list of widths (relative ratio) for each horizontal column in facet
     """
     #: number of columns
     ncol = None
@@ -85,7 +90,9 @@ class facet:
 
     def __init__(self, scales='fixed', shrink=True,
                  labeller='label_value', as_table=True,
-                 drop=True, dir='h'):
+                 drop=True, dir='h',
+				 height_ratios = None, 
+				 width_ratios = None):
         from .labelling import as_labeller
         self.shrink = shrink
         self.labeller = as_labeller(labeller)
@@ -94,6 +101,8 @@ class facet:
         self.dir = dir
         self.free = {'x': scales in ('free_x', 'free'),
                      'y': scales in ('free_y', 'free')}
+        self.height_ratios = height_ratios
+        self.width_ratios = width_ratios
 
     def __radd__(self, gg, inplace=False):
         gg = gg if inplace else deepcopy(gg)
@@ -327,11 +336,18 @@ class facet:
         num_panels = len(layout)
         axsarr = np.empty((self.nrow, self.ncol), dtype=object)
 
+        if self.height_ratios is None:
+            self.height_ratios = [1 for x in range(self.nrow)]
+        if self.width_ratios is None:
+            self.width_ratios = [1 for x in range(self.ncol)]
+
+        gs = GridSpec(self.nrow, self.ncol, height_ratios=self.height_ratios, width_ratios=self.width_ratios)
+
         # Create axes
         i = 1
         for row in range(self.nrow):
             for col in range(self.ncol):
-                axsarr[row, col] = fig.add_subplot(self.nrow, self.ncol, i)
+                axsarr[row, col] = fig.add_subplot(gs[i - 1])
                 i += 1
 
         # Rearrange axes

--- a/plotnine/facets/facet.py
+++ b/plotnine/facets/facet.py
@@ -91,8 +91,8 @@ class facet:
     def __init__(self, scales='fixed', shrink=True,
                  labeller='label_value', as_table=True,
                  drop=True, dir='h',
-                 height_ratios = None, 
-                 width_ratios = None):
+                 height_ratios=None, 
+                 width_ratios=None):
         from .labelling import as_labeller
         self.shrink = shrink
         self.labeller = as_labeller(labeller)
@@ -341,7 +341,10 @@ class facet:
         if self.width_ratios is None:
             self.width_ratios = [1 for x in range(self.ncol)]
 
-        gs = GridSpec(self.nrow, self.ncol, height_ratios=self.height_ratios, width_ratios=self.width_ratios)
+        gs = GridSpec(
+            self.nrow, self.ncol,
+            height_ratios=self.height_ratios,
+            width_ratios=self.width_ratios)
 
         # Create axes
         i = 1

--- a/plotnine/facets/facet_grid.py
+++ b/plotnine/facets/facet_grid.py
@@ -60,14 +60,20 @@ class facet_grid(facet):
         will automatically be dropped. If ``False``, all
         factor levels will be shown, regardless of whether
         or not they appear in the data. Default is ``True``.
+    height_ratios: for example [2, 1]
+        list of heights (relative ratio) for each vertical row in facet
+    width_ratios: for example [1, 1]
+        list of widths (relative ratio) for each horizontal column in facet
     """
 
     def __init__(self, facets, margins=False, scales='fixed',
                  space='fixed', shrink=True, labeller='label_value',
-                 as_table=True, drop=True):
+                 as_table=True, drop=True, 
+                 height_ratios=None, width_ratios=None):
         facet.__init__(
             self, scales=scales, shrink=shrink, labeller=labeller,
-            as_table=as_table, drop=drop)
+            as_table=as_table, drop=drop, 
+            height_ratios=height_ratios, width_ratios=width_ratios)
         self.rows, self.cols = parse_grid_facets(facets)
         self.margins = margins
         self.space_free = {'x': space in ('free_x', 'free'),

--- a/plotnine/facets/facet_grid.py
+++ b/plotnine/facets/facet_grid.py
@@ -87,10 +87,6 @@ class facet_grid(facet):
         will automatically be dropped. If ``False``, all
         factor levels will be shown, regardless of whether
         or not they appear in the data. Default is ``True``.
-    height_ratios: for example [2, 1]
-        list of heights (relative ratio) for each vertical row in facet
-    width_ratios: for example [1, 1]
-        list of widths (relative ratio) for each horizontal column in facet
     """
 
     def __init__(self, facets, margins=False, scales='fixed',

--- a/plotnine/facets/facet_grid.py
+++ b/plotnine/facets/facet_grid.py
@@ -68,11 +68,11 @@ class facet_grid(facet):
 
     def __init__(self, facets, margins=False, scales='fixed',
                  space='fixed', shrink=True, labeller='label_value',
-                 as_table=True, drop=True, 
+                 as_table=True, drop=True,
                  height_ratios=None, width_ratios=None):
         facet.__init__(
             self, scales=scales, shrink=shrink, labeller=labeller,
-            as_table=as_table, drop=drop, 
+            as_table=as_table, drop=drop,
             height_ratios=height_ratios, width_ratios=width_ratios)
         self.rows, self.cols = parse_grid_facets(facets)
         self.margins = margins

--- a/plotnine/facets/facet_grid.py
+++ b/plotnine/facets/facet_grid.py
@@ -39,10 +39,37 @@ class facet_grid(facet):
         Default is ``'fixed'``, the same scales for all the
         panels.
     space : str in ``['fixed', 'free', 'free_x', 'free_y']``
-        Whether the ``x`` or ``y`` sides of the panels
+        indicating whether the ``x`` or ``y`` sides of the panels
         should have the size. It also depends to the
-        ``scales`` parameter. Default is ``'fixed'``.
-        This setting is not yet supported.
+        ``scales`` parameter.
+
+        Alternatively a map indicating relative facet size ratios
+        such as::
+
+            ``{'x': [2,1], 'y': [1,1]}``.
+
+        may be indicated.  Currently only the relative
+        facet size designation is supported, otherwise defaults
+        to ``'fixed'``.
+
+        Relative size works as follows, assuming have n x m
+        facets, the relative size of each facet in the vertical
+        and/or horizontal direction can be indicated.  For
+        example if have three rows of facets in the vertical
+        direction and want to make the top facet 3x larger than
+        the bottom two, would indicate::
+
+            ``{'y': [3,1,1]}``
+
+        If also want to size the horizontal facets, say (2 facets)
+        where the 2nd facet is 2x as large as the 1st, in addition to
+        the vertical sizing above::
+
+            ``{'x': [1,2], 'y': [3,1,1]}``
+
+        Note that the number of dimensions in the list must equal the
+        number of facets that will be produced.
+
     shrink : bool
         Whether to shrink the scales to the output of the
         statistics instead of the raw data. Default is ``True``.
@@ -68,16 +95,19 @@ class facet_grid(facet):
 
     def __init__(self, facets, margins=False, scales='fixed',
                  space='fixed', shrink=True, labeller='label_value',
-                 as_table=True, drop=True,
-                 height_ratios=None, width_ratios=None):
+                 as_table=True, drop=True):
+
+        height_ratios = space["y"] if isinstance(space,dict) and "y" in space else None
+        width_ratios = space["x"] if isinstance(space,dict) and "x" in space else None
+
         facet.__init__(
             self, scales=scales, shrink=shrink, labeller=labeller,
             as_table=as_table, drop=drop,
             height_ratios=height_ratios, width_ratios=width_ratios)
         self.rows, self.cols = parse_grid_facets(facets)
         self.margins = margins
-        self.space_free = {'x': space in ('free_x', 'free'),
-                           'y': space in ('free_y', 'free')}
+        self.space_free = {'x': isinstance(space,str) and space in ('free_x', 'free'),
+                           'y': isinstance(space,str) and space in ('free_y', 'free')}
         self.num_vars_x = len(self.cols)
         self.num_vars_y = len(self.rows)
 


### PR DESCRIPTION
This change allows a user of facet_grid() to specify an optional:

- space={'y': ```<ratios>```}: setting the relative height of vertical facets
  * for example facet_grid("pane ~ .", scales='free_y', space={'y': [2,1,1]}.  This would make the top facet height 2x that of the 2nd and 3rd facet
- space={'x': ```<ratios>```}: setting the relative width of horizontal facets
  * for example space={'x': [1,2,1], ...}
- or a combination of the two:
  * space={'x': [1,2,1], 'y': [2,1,1]}.

A similar extension exists for R ggplot(), though not in the main ggplot package.   Here is an example:
```
import numpy as np
import pandas as pd
import plotnine
from plotnine import *

y = pd.Series(np.random.normal(0.0, 1.0, 400)).cumsum()
df = y.diff().fillna(0.0)
x = np.arange(0,400)

gdf = pd.concat([
    pd.DataFrame({'x': x, 'y': y, 'what': 'y', 'pane': 'cumr'}),
    pd.DataFrame({'x': x, 'y': df, 'what': 'df', 'pane': 'df'}),
])

(ggplot() +
    geom_line(aes(x='x', y='y', color='what'), data=gdf) +
    facet_grid("pane ~ .", scales="free_y", space={'y': [3,1]}))
```
See the attached output included.
<img width="919" alt="example" src="https://user-images.githubusercontent.com/3257426/114314935-c4289f80-9aca-11eb-9444-6018c65e0ed0.png">
