### PR TITLE
Replace deprecated uses of numpy.{float,int}

### DIFF
--- a/plotnine/guides/guide_legend.py
+++ b/plotnine/guides/guide_legend.py
@@ -305,8 +305,8 @@ class guide_legend(guide):
         # labels
         labels = []
         for item in self.key['label']:
-            if isinstance(item, np.float) and np.float.is_integer(item):
-                item = np.int(item)  # 1.0 to 1
+            if isinstance(item, float) and float.is_integer(item):
+                item = int(item)  # 1.0 to 1
             va = 'center' if self.label_position == 'top' else 'baseline'
             ta = TextArea(item, textprops=dict(color='black', va=va))
             labels.append(ta)

--- a/plotnine/stats/binning.py
+++ b/plotnine/stats/binning.py
@@ -32,7 +32,7 @@ def freedman_diaconis_bins(a):
     else:
         bins = np.ceil((np.nanmax(a) - np.nanmin(a)) / h)
 
-    return np.int(bins)
+    return int(bins)
 
 
 def breaks_from_binwidth(x_range, binwidth=None, center=None,
@@ -262,7 +262,7 @@ def fuzzybreaks(scale, breaks=None, boundary=None,
         boundary = round_any(srange[0], binwidth, np.floor)
 
     if recompute_bins:
-        bins = np.int(np.ceil((srange[1]-boundary)/binwidth))
+        bins = int(np.ceil((srange[1]-boundary)/binwidth))
 
     # To minimise precision errors, we do not pass the boundary and
     # binwidth into np.arange as params. The resulting breaks

--- a/plotnine/stats/stat_density.py
+++ b/plotnine/stats/stat_density.py
@@ -140,7 +140,7 @@ class stat_density(stat):
 
 
 def compute_density(x, weight, range, **params):
-    x = np.asarray(x, dtype=np.float)
+    x = np.asarray(x, dtype=float)
     not_nan = ~np.isnan(x)
     x = x[not_nan]
     bw = params['bw']

--- a/plotnine/utils.py
+++ b/plotnine/utils.py
@@ -475,7 +475,7 @@ def jitter(x, factor=1, amount=None, random_state=None):
         z = 1
 
     if amount is None:
-        _x = np.round(x, 3-np.int(np.floor(np.log10(z)))).astype(np.int)
+        _x = np.round(x, 3-int(np.floor(np.log10(z)))).astype(int)
         xx = np.unique(np.sort(_x))
         d = np.diff(xx)
         if len(d):


### PR DESCRIPTION
In some code using plotnine 0.8.0, I get a lot of warnings like:

```
message_data/tests/model/transport/test_report.py: 739 warnings
  /home/khaeru/.local/lib/python3.8/site-packages/plotnine/guides/guide_legend.py:308: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

This PR makes the suggested changes.