### PR TITLE
rename dashed_capstyle

### DIFF
--- a/plotnine/tests/test_theme.py
+++ b/plotnine/tests/test_theme.py
@@ -93,6 +93,36 @@ def test_add_element_blank():
     assert th3.apply.__name__ == 'apply'
 
 
+def test_element_line_dashed_capstyle():
+    p = (
+        ggplot(mtcars, aes(x="wt", y="mpg"))
+        + theme(
+            panel_grid=element_line(
+                linetype="dashed",
+                lineend="butt",
+                size=1.0,
+            )
+        )
+    )
+    # no exception
+    p._build()
+
+
+def test_element_line_solid_capstyle():
+    p = (
+        ggplot(mtcars, aes(x="wt", y="mpg"))
+        + theme(
+            panel_grid=element_line(
+                linetype="solid",
+                lineend="butt",
+                size=1.0,
+            )
+        )
+    )
+    # no exception
+    p._build()
+
+
 class TestThemes:
     g = (ggplot(mtcars, aes(x='wt', y='mpg', color='factor(gear)'))
          + geom_point()

--- a/plotnine/themes/elements.py
+++ b/plotnine/themes/elements.py
@@ -41,7 +41,7 @@ class element_line:
         if linetype in ('solid', '-') and lineend:
             d['solid_capstyle'] = lineend
         elif linetype and lineend:
-            d['dashed_capstyle'] = lineend
+            d['dash_capstyle'] = lineend
 
         d.update(**kwargs)
         self.properties = d


### PR DESCRIPTION
the correct matplotlib keyword is `dash_capstyle`

to reproduce, create a chart with the following 

```python
pn.theme(
    panel_grid=pn.element_line(
        linetype="dashed", lineend="butt"
    )
)
```

which yields the following error

```
ValueError: keyword grid_dashed_capstyle is not recognized; valid keywords are ['size', 'width', 'color', 'tickdir', 'pad', 'labelsize', 'labelcolor', 'zorder', 'gridOn', 'tick1On', 'tick2On', 'label1On', 'label2On', 'length', 'direction', 'left', 'bottom', 'right', 'top', 'labelleft', 'labelbottom', 'labelright', 'labeltop', 'labelrotation', 'grid_agg_filter', 'grid_alpha', 'grid_animated', 'grid_antialiased', 'grid_clip_box', 'grid_clip_on', 'grid_clip_path', 'grid_color', 'grid_contains', 'grid_dash_capstyle', 'grid_dash_joinstyle', 'grid_dashes', 'grid_data', 'grid_drawstyle', 'grid_figure', 'grid_fillstyle', 'grid_gid', 'grid_in_layout', 'grid_label', 'grid_linestyle', 'grid_linewidth', 'grid_marker', 'grid_markeredgecolor', 'grid_markeredgewidth', 'grid_markerfacecolor', 'grid_markerfacecoloralt', 'grid_markersize', 'grid_markevery', 'grid_path_effects', 'grid_picker', 'grid_pickradius', 'grid_rasterized', 'grid_sketch_params', 'grid_snap', 'grid_solid_capstyle', 'grid_solid_joinstyle', 'grid_transform', 'grid_url', 'grid_visible', 'grid_xdata', 'grid_ydata', 'grid_zorder', 'grid_aa', 'grid_c', 'grid_ds', 'grid_ls', 'grid_lw', 'grid_mec', 'grid_mew', 'grid_mfc', 'grid_mfcalt', 'grid_ms']
```
