### PR TITLE
Fix typo in docstring Caterogical -> Categorical

### DIFF
--- a/plotnine/mapping/aes.py
+++ b/plotnine/mapping/aes.py
@@ -112,7 +112,7 @@ class aes(dict):
     mapped.
 
         1. ``factor`` - This function turns the variable into a factor.
-            It is just an alias to ``pd.Caterogical``::
+            It is just an alias to ``pd.Categorical``::
 
                 ggplot(mtcars, aes(x='factor(cyl)')) + geom_bar()
 


### PR DESCRIPTION
Loving plotnine, thanks for all the hardwork! 
Discovered `factor()`, very useful, and noticed a tiny typo in a docstring. Thought I'd contribute my 2 pences :) (more like 0.00002 pences, I guess)