### PR TITLE
Title align

### DIFF
--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -586,6 +586,11 @@ class ggplot:
         except KeyError:
             strip_margin_y = 0
 
+        try:
+            ha = get_property('plot_title', 'ha')
+        except KeyError:
+            ha = 'center'
+
         dpi = 72.27
         line_size = fontsize / dpi
         num_lines = len(title.split('\n'))
@@ -596,10 +601,17 @@ class ggplot:
         # vertical adjustment
         strip_height *= (1 + strip_margin_y)
 
-        x = 0.5
+        if ha == 'left':
+            x = 0.12
+        elif ha == 'right':
+            x = 0.9
+        else:
+            # ha='center' is default
+            x = 0.5
+
         y = top + (strip_height+title_size/2+pad)/H
 
-        text = figure.text(x, y, title, ha='center', va='center')
+        text = figure.text(x, y, title, ha=ha, va='center')
         figure._themeable['plot_title'] = text
 
     def _draw_watermarks(self):

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -602,7 +602,7 @@ class ggplot:
         strip_height *= (1 + strip_margin_y)
 
         if ha == 'left':
-            x = 0.12
+            x = 0.125
         elif ha == 'right':
             x = 0.9
         else:


### PR DESCRIPTION
Fixes #556.

When using a theme to pass a `plot_title` alignment, this change assumes you want to reposition the title accordingly. That way left-anchored title is also left-aligned, and a right-anchored title is also right-aligned.

I wasn't sure how to calculate the positions in a more appropriate way, so it just uses numbers that seem to make it work. `ha='left'` is `x=0.125` and `ha='right'` is `x=0.9`.

**Default center**

```python
(
    ggplot(df, aes(x='x', y='y'))
    + labs(title = 'Plot title')
)
```

![default center alignment](https://user-images.githubusercontent.com/95126/149927622-3cd05808-d495-47f1-aefb-7d346e304236.png)

**Left-aligned**

```python
(
    ggplot(df, aes(x='x', y='y'))
    + labs(title='Plot title')
    + theme(plot_title=element_text(ha='left'))
)
```

![left-aligned title](https://user-images.githubusercontent.com/95126/149929050-fa7f3afe-f4a0-4ec5-bd20-4314892ea027.png)

```python
(
    ggplot(df, aes(x='x', y='y'))
    + labs(title='Plot title')
    + theme(plot_title=element_text(ha='right'))
)
```

![right-aligned](https://user-images.githubusercontent.com/95126/149927797-23e3d7da-78f5-4606-807e-051957346e00.png)

**If you're especially picky you can still pass `x`**

```python
(
    ggplot(df, aes(x='x', y='y'))
    + labs(title='Plot title')
    + theme(plot_title=element_text(ha='left', x=0))
)
```

![pass custom x location](https://user-images.githubusercontent.com/95126/149927907-b7dd1ee4-76ff-4e9c-8316-f9fd257008f9.png)

**Works with facets**, which was the only other non-standard situation I could think of

```python
(
    ggplot(df, aes(x='x', y='y'))
    + labs(title='Plot title')
    + facet_wrap('~z')
    + theme(plot_title=element_text(ha='right'))
)
```

![image](https://user-images.githubusercontent.com/95126/149928055-cf84111e-e09d-4a23-bf4c-a2aab2955551.png)
