### PR TITLE
fix: explicitly extract xy coords from 3D-LineString

### DIFF
--- a/plotnine/geoms/geom_map.py
+++ b/plotnine/geoms/geom_map.py
@@ -136,7 +136,10 @@ class geom_map(geom):
             segments = []
             for g in data['geometry']:
                 if g.geom_type == 'LineString':
-                    segments.append(g.coords)
+                    if g.has_z:
+                        segments.append([(x, y) for x, y, _ in g.coords])
+                    else:
+                        segments.append(g.coords)
                 else:
                     segments.extend(_g.coords for _g in g.geoms)
 


### PR DESCRIPTION
I've been dealing with some trajectory calculations which end up producing 3D LineStrings as geometry. 

I am, however, unable to use `geom_map` with this kind of `GeoDataFrame` since `plotnine` expects xy coordinates and fails when the `geometry.coords` object contains tuples with a `z` dimension.

It would also be nice to be able to use the `z` dimension for some other aesthetics, such as color, for instance. My solution for now has been to generate `Point` geometries from the LineStrings and use `geom_path` instead of `geom_map`, but it would be great if this could be handled directly when passing a LineString geometry.

This little fix makes 3D linestrings not throw an error, but does so by completely disregarding the `z` dimension. I am not completely sure of how to fix this to be able to use `z` as an extra aesthetic without explicitly reverting the LineString into Points...