### PR TITLE
Updated an instance of df.append() called out by latest version of pandas

### DIFF
--- a/plotnine/utils.py
+++ b/plotnine/utils.py
@@ -368,7 +368,7 @@ def join_keys(x, y, by=None):
     if isinstance(by, tuple):
         by = list(by)
 
-    joint = x[by].append(y[by], ignore_index=True)
+    joint = pd.concat([x[by], y[by]], ignore_index=True)
     keys = ninteraction(joint, drop=True)
     keys = np.asarray(keys)
     nx, ny = len(x), len(y)


### PR DESCRIPTION
I updated the pandas and got the following deprecation warning:

${anaconda3_home}/lib/python3.9/site-packages/plotnine/utils.py:371: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead

Naively implemented an update without validating. I don't know how to use a local package to test. 