### PR TITLE
Fix typo in doc for `lims`

### DIFF
--- a/plotnine/scales/limits.py
+++ b/plotnine/scales/limits.py
@@ -152,7 +152,7 @@ class strokelim(_lim):
 
 class lims:
     """
-    Set aesthtic limits
+    Set aesthetic limits
 
     Parameters
     ----------


### PR DESCRIPTION
Missing a single character in the word "aesthetic" in the `lims` doctrstrings in plotnine/scales/limits.py