### PR TITLE
docs: Fix a few typos

### DIFF
--- a/plotnine/geoms/annotate.py
+++ b/plotnine/geoms/annotate.py
@@ -15,7 +15,7 @@ class annotate:
     Parameters
     ----------
     geom : geom or str
-        geom to use for annoation, or name of geom (e.g. 'point').
+        geom to use for annotation, or name of geom (e.g. 'point').
     x : float
         Position
     y : float

--- a/plotnine/geoms/geom.py
+++ b/plotnine/geoms/geom.py
@@ -240,7 +240,7 @@ class geom(metaclass=Registry):
         """
         Plot all groups
 
-        For effeciency, geoms that do not need to partition
+        For efficiency, geoms that do not need to partition
         different groups before plotting should override this
         method and avoid the groupby.
 


### PR DESCRIPTION
There are small typos in:
- plotnine/geoms/annotate.py
- plotnine/geoms/geom.py

Fixes:
- Should read `efficiency` rather than `effeciency`.
- Should read `annotation` rather than `annoation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md