### PR TITLE
Enable 3D subplots support for facets

### DIFF
--- a/plotnine/facets/facet.py
+++ b/plotnine/facets/facet.py
@@ -317,7 +317,7 @@ class facet:
         """
         Create suplots and return axs
         """
-        num_panels = len(layout)
+        num_panels = len(layout.layout)
         axsarr = np.empty((self.nrow, self.ncol), dtype=object)
         space = self.space
         default_space = {
@@ -360,7 +360,10 @@ class facet:
         i = 1
         for row in range(self.nrow):
             for col in range(self.ncol):
-                axsarr[row, col] = fig.add_subplot(gs[i - 1])
+                axsarr[row, col] = fig.add_subplot(
+                    gs[i - 1],
+                    projection=layout.projection
+                )
                 i += 1
 
         # Rearrange axes

--- a/plotnine/facets/layout.py
+++ b/plotnine/facets/layout.py
@@ -27,6 +27,8 @@ class Layout:
 
     axs = None        # MPL axes
 
+    projection = None     # MPL projection
+
     def setup(self, layers, plot):
         """
         Create a layout for the panels

--- a/plotnine/facets/strips.py
+++ b/plotnine/facets/strips.py
@@ -5,6 +5,13 @@ with suppress(ImportError):
     import matplotlib.text as mtext
     import matplotlib.patches as mpatch
 
+try:
+    from mpl_toolkits.mplot3d import art3d
+    from mpl_toolkits.mplot3d.axes3d import Axes3D
+    MPLOT3D_AVAILABLE = True
+except ImportError:
+    MPLOT3D_AVAILABLE = False
+
 
 class strips(list):
     """
@@ -281,6 +288,9 @@ class strip:
             zorder=3.3,  # > rect
             clip_on=False
         )
+
+        if MPLOT3D_AVAILABLE and isinstance(ax, Axes3D):
+            art3d.patch_2d_to_3d(rect)
 
         ax.add_artist(rect)
         ax.add_artist(text)

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -78,6 +78,7 @@ class ggplot:
         self.figure = None
         self.watermarks = []
         self.axs = None
+        self._layout_class = Layout
 
     def __str__(self):
         """
@@ -268,7 +269,7 @@ class ggplot:
         if not self.layers:
             self += geom_blank()
 
-        self.layout = Layout()
+        self.layout = self._layout_class()
         layers = self.layers
         scales = self.scales
         layout = self.layout
@@ -365,7 +366,7 @@ class ggplot:
         figure = plt.figure()
         axs = self.facet.make_axes(
             figure,
-            self.layout.layout,
+            self.layout,
             self.coordinates)
 
         # Dictionary to collect matplotlib objects that will


### PR DESCRIPTION
Enable 3D subplots support for facets when custom layout with 3d projection is provided, partially addressing #582.

There are three changes:
- adding `projection` attribute to `Layout`
- allowing to substitute `Layout` in `ggplot` subclasses
- converting `FancyBboxPatch` to 3D if 3D axes are detected (without it all `facet_*()` would need be subclassed only to update the `strip()` call with a custom subclass of it).

I wonder if `projection` attribute could be also useful for `coord_polar` as it can be set to "polar"; if that is the case and therefore it should be moved elsewhere (other than layout), I would be happy with that as well.

Example of what it enables:

![image](https://user-images.githubusercontent.com/5832902/180644473-cf1685bc-7559-4be9-9f29-d335cb60e42f.png)
