### PR TITLE
fix passing of dparams when using stat_qq

### DIFF
--- a/plotnine/stats/stat_qq.py
+++ b/plotnine/stats/stat_qq.py
@@ -78,6 +78,6 @@ class stat_qq(stat):
 
         quantiles = np.asarray(quantiles)
         cdist = get_continuous_distribution(params['distribution'])
-        theoretical = cdist.ppf(quantiles, *params['dparams'])
+        theoretical = cdist.ppf(quantiles, **params['dparams'])
         return pd.DataFrame({'sample': sample,
                              'theoretical': theoretical})

--- a/plotnine/stats/stat_qq.py
+++ b/plotnine/stats/stat_qq.py
@@ -60,7 +60,7 @@ class stat_qq(stat):
     DEFAULT_AES = {'x': after_stat('theoretical'), 'y': after_stat('sample')}
     DEFAULT_PARAMS = {'geom': 'qq', 'position': 'identity',
                       'na_rm': False,
-                      'distribution': 'norm', 'dparams': (),
+                      'distribution': 'norm', 'dparams': {},
                       'quantiles': None, 'alpha_beta': (3/8, 3/8)}
 
     @classmethod

--- a/plotnine/stats/stat_qq_line.py
+++ b/plotnine/stats/stat_qq_line.py
@@ -52,7 +52,7 @@ class stat_qq_line(stat):
     REQUIRED_AES = {'sample'}
     DEFAULT_PARAMS = {'geom': 'qq_line', 'position': 'identity',
                       'na_rm': False,
-                      'distribution': 'norm', 'dparams': (),
+                      'distribution': 'norm', 'dparams': {},
                       'quantiles': None, 'alpha_beta': (3/8, 3/8),
                       'line_p': (0.25, 0.75), 'fullrange': False}
     CREATES = {'x', 'y'}
@@ -76,7 +76,7 @@ class stat_qq_line(stat):
 
         # Compute slope & intercept of the line through the quantiles
         cdist = get_continuous_distribution(params['distribution'])
-        x_coords = cdist.ppf(line_p, *dparams)
+        x_coords = cdist.ppf(line_p, **dparams)
         y_coords = mquantiles(sample, line_p)
         slope = (np.diff(y_coords)/np.diff(x_coords))[0]
         intercept = y_coords[0] - slope*x_coords[0]


### PR DESCRIPTION
`stat_qq` unpacks `dparams` in wrong way when passing them to `cdist.ppf` resulting in an error so far; this fixes #635 

I hope the PR is ok, I wasn't sure if/how I should add a test, I'm happy about feedback.