### PR TITLE
Type hint user-facing methods of ggplot (and watermark)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -107,7 +107,9 @@ jobs:
 
       - name: Install Packages
         shell: bash -l {0}
-        run: pip install mypy
+        run: |
+          pip install "."
+          pip install -r requirements/typing.txt
 
       - name: Environment Information
         shell: bash -l {0}

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,6 +35,11 @@ warn_unreachable = True
 
 # Ignores all non-fatal errors.
 ignore_errors = True
+show_error_codes = True
+
+# foreign modules that are missing types or type stubs
+[mypy-pandas.*,matplotlib.*,patsy.*,mizani.*]
+ignore_missing_imports = True
 
 # per module options
 [mypy-plotnine.labels]
@@ -48,3 +53,14 @@ ignore_errors = False
 
 [mypy-plotnine.watermark]
 ignore_errors = False
+
+[mypy-plotnine.ggplot,plotnine.utils]
+ignore_errors = False
+disallow_untyped_defs = False
+
+[mypy-plotnine.typing]
+ignore_errors = False
+
+[mypy-plotnine.layer]
+ignore_errors = False
+disallow_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -45,3 +45,6 @@ ignore_errors = False
 
 [mypy-plotnine.exceptions]
 ignore_errors = False
+
+[mypy-plotnine.watermark]
+ignore_errors = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,10 +35,9 @@ warn_unreachable = True
 
 # Ignores all non-fatal errors.
 ignore_errors = True
-show_error_codes = True
 
 # foreign modules that are missing types or type stubs
-[mypy-pandas.*,matplotlib.*,patsy.*,mizani.*]
+[mypy-matplotlib.*,patsy.*,mizani.*]
 ignore_missing_imports = True
 
 # per module options

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -749,16 +749,7 @@ class ggplot:
         fig.savefig(filename, **fig_kwargs)
 
 
-# could be replaced with just
-# ggsave = ggplot.save
-# with better typing but without the deprecation message in the help.
-def ggsave(plot: ggplot, *arg: Any, **kwargs: Any) -> None:
-    """
-    Save a ggplot object as an image file
-
-    Use :meth:`ggplot.save` instead
-    """
-    return plot.save(*arg, **kwargs)
+ggsave = ggplot.save
 
 
 def save_as_pdf_pages(

--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
+
 import sys
+import typing
 from collections.abc import Sequence
 from copy import deepcopy
 from itertools import chain
 from pathlib import Path
 from types import SimpleNamespace as NS
+from typing import Any, Iterable, Union
 from warnings import warn
 
 import pandas as pd
@@ -29,7 +32,7 @@ from .guides.guides import guides
 
 # mypy believes there is a duplicate definition
 # of geom_blank even though it only appears once
-from .geoms import geom_blank   # type: ignore[no-redef]  # mypy bug
+from .geoms import geom_blank  # type: ignore[no-redef]  # mypy bug
 
 from .utils import (
     defaults,
@@ -40,11 +43,9 @@ from .utils import (
     ungroup
 )
 
-import typing
-from typing import Any, Iterable, Union
-
 if typing.TYPE_CHECKING:
     import plotnine as p9
+
     from .typing import DataLike, PlotAddable
 
 # Show plots if in interactive mode

--- a/plotnine/layer.py
+++ b/plotnine/layer.py
@@ -170,7 +170,6 @@ class layer:
         self.inherit_aes = inherit_aes
         self.show_legend = show_legend
         self.raster = raster
-        self._active_mapping = {}
         self.zorder = 0
 
     @staticmethod

--- a/plotnine/layer.py
+++ b/plotnine/layer.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+
+import typing
 from copy import copy, deepcopy
+from typing import List
 
 import pandas as pd
 
@@ -9,14 +12,13 @@ from .utils import check_required_aesthetics, defaults
 from .mapping.aes import aes, NO_GROUP, SCALED_AESTHETICS
 from .mapping.evaluation import stage, evaluate
 
-import typing
-from typing import List
 if typing.TYPE_CHECKING:
     import plotnine as p9
+
     from .geoms.geom import geom
     from .positions.position import position
     from .stats.stat import stat
-    from .typing import DataLike, LayerDataLike, DataFrameConvertible
+    from .typing import DataFrameConvertible, DataLike, LayerDataLike
 
 
 class Layers(List["layer"]):

--- a/plotnine/layer.py
+++ b/plotnine/layer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from copy import copy, deepcopy
 
 import pandas as pd
@@ -8,8 +9,17 @@ from .utils import check_required_aesthetics, defaults
 from .mapping.aes import aes, NO_GROUP, SCALED_AESTHETICS
 from .mapping.evaluation import stage, evaluate
 
+import typing
+from typing import List
+if typing.TYPE_CHECKING:
+    import plotnine as p9
+    from .geoms.geom import geom
+    from .positions.position import position
+    from .stats.stat import stat
+    from .typing import DataLike, LayerDataLike, DataFrameConvertible
 
-class Layers(list):
+
+class Layers(List["layer"]):
     """
     List of layers
 
@@ -47,7 +57,7 @@ class Layers(list):
     def data(self):
         return [l.data for l in self]
 
-    def setup(self, plot):
+    def setup(self, plot: p9.ggplot) -> None:
         for l in self:
             l.setup(plot)
 
@@ -141,9 +151,17 @@ class layer:
     always use a ``geom`` or ``stat``.
     """
 
-    def __init__(self, geom=None, stat=None, data=None, mapping=None,
-                 position=None, inherit_aes=True, show_legend=None,
-                 raster=False):
+    def __init__(
+        self,
+        geom: geom | None = None,
+        stat: stat | None = None,
+        data: LayerDataLike | None = None,
+        mapping: aes | None = None,
+        position: position | None = None,
+        inherit_aes: bool = True,
+        show_legend: bool | None = None,
+        raster: bool = False
+    ) -> None:
         self.geom = geom
         self.stat = stat
         self.data = data
@@ -214,7 +232,7 @@ class layer:
 
         return result
 
-    def setup(self, plot):
+    def setup(self, plot: p9.ggplot) -> None:
         """
         Prepare layer for the plot building
 
@@ -224,7 +242,7 @@ class layer:
         self._make_layer_mapping(plot.mapping)
         self._make_layer_environments(plot.environment)
 
-    def _make_layer_data(self, plot_data):
+    def _make_layer_data(self, plot_data: DataLike | None) -> None:
         """
         Generate data to be used by this layer
 
@@ -234,25 +252,29 @@ class layer:
             ggplot object data
         """
         if plot_data is None:
-            plot_data = pd.DataFrame()
+            data = pd.DataFrame()
         elif callable(plot_data):
-            plot_data = plot_data()
+            data = plot_data()
+        elif hasattr(plot_data, "to_pandas"):
+            data = typing.cast("DataFrameConvertible", plot_data).to_pandas()
+        else:
+            data = typing.cast("pd.DataFrame", plot_data)
 
         # Each layer that does not have data gets a copy of
         # of the ggplot.data. If it has data it is replaced
         # by copy so that we do not alter the users data
         if self.data is None:
             try:
-                self.data = copy(plot_data)
+                self.data = copy(data)
             except AttributeError:
                 _geom_name = self.geom.__class__.__name__
-                _data_name = plot_data.__class__.__name__
+                _data_name = data.__class__.__name__
                 raise PlotnineError(
                     f"{_geom_name} layer expects a dataframe, "
                     f"but it got {_data_name} instead."
                 )
         elif callable(self.data):
-            self.data = self.data(plot_data)
+            self.data = self.data(data)
             if not isinstance(self.data, pd.DataFrame):
                 raise PlotnineError(
                     "Data function must return a Pandas dataframe"
@@ -260,9 +282,11 @@ class layer:
         else:
             self.data = copy(self.data)
 
-        # Recognise polars dataframes
-        if hasattr(self.data, "to_pandas"):
-            self.data = self.data.to_pandas()
+            # Recognise polars dataframes
+            if hasattr(self.data, "to_pandas"):
+                self.data = (
+                    typing.cast("DataFrameConvertible", self.data).to_pandas()
+                )
 
     def _make_layer_mapping(self, plot_mapping):
         """

--- a/plotnine/typing.py
+++ b/plotnine/typing.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
+
 import typing
 
 if typing.TYPE_CHECKING:
     from typing import Callable, Protocol
-    from typing_extensions import TypeAlias
+
     import pandas as pd
+    from typing_extensions import TypeAlias
+
     import plotnine as p9
 
     class PlotAddable(Protocol):

--- a/plotnine/typing.py
+++ b/plotnine/typing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Callable, Protocol
+    from typing_extensions import TypeAlias
+    import pandas as pd
+    import plotnine as p9
+
+    class PlotAddable(Protocol):
+        def __radd__(self, other: p9.ggplot) -> p9.ggplot:
+            ...
+
+    class DataFrameConvertible(Protocol):
+        def to_pandas(self) -> pd.DataFrame:
+            ...
+
+    # Input data can be a DataFrame, a DataFrame factory or things that
+    # are convertible to DataFrames.
+    # `Data` is mostly used internally and `DataLike` is the input type
+    # before automatic conversion.
+    # Input data can actually also contain DataFrameGroupBy which is
+    # specially handled, but pandas doesn't expose that data type in
+    # their type stubs and instead treats it the same as a DataFrame
+    # (df.groupby() returns a DataFrame in the stubs).
+    Data: TypeAlias = "pd.DataFrame | Callable[[], pd.DataFrame]"
+    DataLike: TypeAlias = "Data | DataFrameConvertible"
+
+    LayerData: TypeAlias = (
+        "pd.DataFrame | Callable[[pd.DataFrame], pd.DataFrame]"
+    )
+    LayerDataLike: TypeAlias = "LayerData | DataFrameConvertible"

--- a/plotnine/utils.py
+++ b/plotnine/utils.py
@@ -2,9 +2,11 @@
 Little functions used all over the codebase
 """
 from __future__ import annotations
+
 import collections
 import itertools
 import inspect
+import typing
 import warnings
 from contextlib import suppress
 from typing import Any, Callable
@@ -14,24 +16,22 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 import pandas.api.types as pdtypes
-
-# missing in type stubs
-from pandas.core.groupby import DataFrameGroupBy  # type: ignore
-
 import matplotlib.colors as mcolors
 from matplotlib.colors import colorConverter
 from matplotlib.offsetbox import DrawingArea
 from matplotlib.patches import Rectangle
 from mizani.bounds import zero_range
 from mizani.utils import multitype_sort
+# missing in type stubs
+from pandas.core.groupby import DataFrameGroupBy  # type: ignore
 
 from .mapping import aes
 from .exceptions import PlotnineError, PlotnineWarning
 
-import typing
 if typing.TYPE_CHECKING:
-    from .typing import DataLike
     from typing_extensions import TypeGuard
+
+    from .typing import DataLike
 
 # Points and lines of equal size should give the
 # same visual diameter (for points) and thickness

--- a/plotnine/watermark.py
+++ b/plotnine/watermark.py
@@ -1,4 +1,13 @@
+from __future__ import annotations
+
 import matplotlib.image as mimage
+
+import typing
+if typing.TYPE_CHECKING:
+    from typing import Any
+    import plotnine as p9
+    import pathlib
+    import matplotlib.figure
 
 
 class watermark:
@@ -24,21 +33,28 @@ class watermark:
     You can add more than one watermark to a plot.
     """
 
-    def __init__(self, filename, xo=0, yo=0, alpha=None, **kwargs):
+    def __init__(
+        self,
+        filename: str | pathlib.Path,
+        xo: int = 0,
+        yo: int = 0,
+        alpha: float | None = None,
+        **kwargs: Any
+    ):
         self.filename = filename
         kwargs.update(xo=xo, yo=yo, alpha=alpha)
         if 'zorder' not in kwargs:
             kwargs['zorder'] = 99.9
         self.kwargs = kwargs
 
-    def __radd__(self, gg):
+    def __radd__(self, gg: p9.ggplot) -> p9.ggplot:
         """
         Add watermark to ggplot object
         """
         gg.watermarks.append(self)
         return gg
 
-    def draw(self, figure):
+    def draw(self, figure: matplotlib.figure.Figure) -> None:
         """
         Draw watermark
 

--- a/plotnine/watermark.py
+++ b/plotnine/watermark.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import typing
+
 import matplotlib.image as mimage
 
-import typing
 if typing.TYPE_CHECKING:
-    from typing import Any
-    import plotnine as p9
     import pathlib
+    from typing import Any
+
     import matplotlib.figure
+
+    import plotnine as p9
 
 
 class watermark:

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -1,0 +1,2 @@
+mypy
+pandas-stubs


### PR DESCRIPTION
Add type hints to the public facing API of the central ggplot class (plus the watermark class). Some other functions are also type hinted to aid in the typing of the ggplot class.
I've added a submodule `typing` to add protocols and unions of general concepts that apply across the library. Numpy uses a submodule of the same name. Should I make this module pseudo-private (e.g. rename it to `_typing`) in the beginning?
Eventually, it should be public.

Mypy has released a new version 2 days ago and implicit optional types have been removed. I've addded explicit notations to fix the errors. Error codes are now shown by default so I've removed the setting from mypy.ini.

A note on import style, I see you are preferring relative imports for intra-package imports and I'm trying tried to conform to this, but there are cases where a relative import will result in a type error because mypy thinks I'm referring to the module and not the class. That's where I'm falling back to absolute imports. It happens in cases like this
```python
from . import ggplot
foo: ggplot  # err about a module not being valid as type
```