### PR TITLE
legend: use figure artist instead of axis artist

### DIFF
--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -495,8 +495,8 @@ class ggplot:
 
         anchored_box.set_zorder(90.1)
         self.figure._themeable['legend_background'] = anchored_box
-        ax = self.axs[0]
-        ax.add_artist(anchored_box)
+        self.figure.add_artist(anchored_box)
+
 
     def _draw_labels(self):
         """


### PR DESCRIPTION
When positioning a legend in an faceted plot in an facet != ax[0], the legend is not drawn in front of the facets, but behind them. This behavior is different from ggplot.

Without the Patch:

![broken](https://user-images.githubusercontent.com/111866/205150889-03852c2a-e931-4f35-858f-0689e4cbf5df.png)

With the Patch:

![good](https://user-images.githubusercontent.com/111866/205150934-3c9f2642-6ba3-47d5-a60d-a21201011e86.png)
