### PR TITLE
Save file with actual pixel dimensions

### DIFF
--- a/plotnine/ggplot.py
+++ b/plotnine/ggplot.py
@@ -659,7 +659,6 @@ class ggplot:
         Use it to get access to the figure that will be saved.
         """
         fig_kwargs: Dict[str, Any] = {
-            "bbox_inches": "tight",  # 'tight' is a good default
             "format": format,
         }
         fig_kwargs.update(kwargs)
@@ -774,6 +773,7 @@ class ggplot:
             verbose=verbose,
             **kwargs,
         )
+        sv.figure.tight_layout()
         sv.figure.savefig(**sv.kwargs)
 
 


### PR DESCRIPTION
When a figure has a specified size, the tight layout causes the outside to be trimmed off, so the resulting .png file is smaller than specified. For example, one might expect this code to generate a 600x400 image.

```py
from plotnine import *
from plotnine.data import mtcars

p = ggplot(mtcars, aes('wt', 'mpg')) + geom_point()
p.save("test.png", width=6, height=4, dpi=100)
```

The result on my Mac, however, is 528x374. This is a result of using `fig.savefig(bbox_inches='tight')`. Here is the generated png:

![test-orig](https://user-images.githubusercontent.com/86978/218900036-d98fb6fc-fb5d-4086-b651-fec7438ce1bb.png)


With this PR, the resulting image is the exact specified dimension. It does this by calling `fig.tight_layout()` before `fig.savefig()`. Here is the generated png after the change:

![test](https://user-images.githubusercontent.com/86978/218900078-24515cce-9fec-48ee-9161-b8264302ca6c.png)
