### PR TITLE
Fix typo in ggpy URL in about page

### DIFF
--- a/doc/about-plotnine.rst
+++ b/doc/about-plotnine.rst
@@ -47,4 +47,4 @@ Built with
 .. _scipy: https://scipy.org
 .. _mizani: https://mizani.readthedocs.io
 .. _ggplot2: http://ggplot2.org
-.. _ggpy: https://github.com/yhat/ggpy`
+.. _ggpy: https://github.com/yhat/ggpy


### PR DESCRIPTION
The [About plotnine](https://plotnine.readthedocs.io/en/stable/about-plotnine.html) page has a backtick at the end of the ggpy URL.  This would remove that character to fix the link.