### PR TITLE
ENH: support more style params for `guide_colorbar`

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,9 +10,12 @@ v0.12.2
 Enhancements
 ************
 
+- :class:`~plotnin.guide.guide_colorbar` Now supports additional 
+  styling parameters: `frame_color`, `frame_linewidth`, 
+  `ticks_color`, `ticks_linewidth`.
+
 - All `__all__` variables are explicitly assigned to help static typecheckers
   infer module attributes. (:issue:`685`)
-
 
 v0.12.1
 -------

--- a/plotnine/guides/guide_colorbar.py
+++ b/plotnine/guides/guide_colorbar.py
@@ -33,8 +33,16 @@ class guide_colorbar(guide):
         a smoother colorbar. Default is 20.
     raster : bool
         Whether to render the colorbar as a raster object.
+    frame_color : None
+        Color of surrounding frame. If None, no frame is drawn.
+    frame_linewidth : float
+        Line width of frame. Default is 1.
     ticks : bool
         Whether tick marks on colorbar should be visible.
+    ticks_color : str
+        Color to use for ticks. Default is "#CCCCCC".
+    ticks_linewidth : float
+        Width of the tick marks. Default is 1.
     draw_ulim : bool
         Whether to show the upper limit tick marks.
     draw_llim : bool
@@ -51,9 +59,13 @@ class guide_colorbar(guide):
     barheight = None
     nbin = 20  # maximum number of bins
     raster = True
+    frame_color = None
+    frame_linewidth = 1
 
     # ticks
     ticks = True
+    ticks_color = "#CCCCCC"
+    ticks_linewidth = 1
     draw_ulim = True
     draw_llim = True
 
@@ -214,7 +226,18 @@ class guide_colorbar(guide):
             if not self.draw_llim:
                 _locations = _locations[1:]
 
-            add_ticks(da, _locations, direction)
+            add_ticks(
+                da,
+                _locations,
+                direction,
+                self.ticks_color,
+                self.ticks_linewidth,
+            )
+
+        if self.frame_color:
+            add_frame(
+                da, width, height, self.frame_color, self.frame_linewidth
+            )
 
         # labels #
         if self.label:
@@ -262,6 +285,24 @@ class guide_colorbar(guide):
         return box
 
 
+def add_frame(da, width, height, color, linewidth):
+    """
+    Add frame to colorbar
+    """
+    from matplotlib.patches import Rectangle
+
+    rect = Rectangle(
+        (0, 0),
+        width,
+        height,
+        edgecolor=color,
+        linewidth=linewidth,
+        facecolor="none",
+        snap=True,
+    )
+    da.add_artist(rect)
+
+
 def add_interpolated_colorbar(da, colors, direction):
     """
     Add 'rastered' colorbar to DrawingArea
@@ -307,7 +348,6 @@ def add_interpolated_colorbar(da, colors, direction):
         coordinates,
         antialiased=False,
         shading="gouraud",
-        linewidth=0,
         cmap=cmap,
         array=Z.ravel(),
     )
@@ -344,7 +384,7 @@ def add_segmented_colorbar(da, colors, direction):
     da.add_artist(coll)
 
 
-def add_ticks(da, locations, direction):
+def add_ticks(da, locations, direction, color, linewidth):
     from matplotlib.collections import LineCollection
 
     segments = []
@@ -368,7 +408,7 @@ def add_ticks(da, locations, direction):
             )
 
     coll = LineCollection(
-        segments, color="#CCCCCC", linewidth=1, antialiased=False
+        segments, color=color, linewidth=linewidth, antialiased=False
     )
     da.add_artist(coll)
 


### PR DESCRIPTION
This PR addresses #653, along with adding the other related parameters from the `ggplot2` implementation.

Example:
```python
import numpy as np
import pandas as pd

from plotnine import (
    aes,
    element_blank,
    geom_tile,
    ggplot,
    guide_colorbar,
    scale_fill_continuous,
    theme,
)

df = pd.DataFrame(
    {
        "value": np.random.randn(100),
        "variable": np.tile(["A", "B", "C", "D", "E"], 20),
        "time": np.repeat(np.arange(1, 21), 5),
    }
)

(
    ggplot(df, aes("variable", "time", fill="value"))
    + geom_tile()
    + scale_fill_continuous(
        guide=guide_colorbar(frame_color="black", ticks_color="black")
    )
    + theme(panel_background=element_blank(),figure_size=(3,3))
)
```

![colorbar](https://github.com/has2k1/plotnine/assets/47667941/776cab85-fc56-4e3a-a83a-d240d55f7f21)
