### PR TITLE
FIPS Compliance

### DIFF
--- a/doc/_config.py
+++ b/doc/_config.py
@@ -46,8 +46,8 @@ def copy_examples_and_tutorials():
     # NOTE: To avoid confusing the watcher used by "quarto preview",
     # we copy only if the original files are different.
     def same_contents(f1, f2):
-        h1 = hashlib.md5(f1.read_bytes()).hexdigest()
-        h2 = hashlib.md5(f2.read_bytes()).hexdigest()
+        h1 = hashlib.sha256(f1.read_bytes()).hexdigest()
+        h2 = hashlib.sha256(f2.read_bytes()).hexdigest()
         return h1 == h2
 
     def copy(src_dir, dest_dir):

--- a/plotnine/guides/guide_colorbar.py
+++ b/plotnine/guides/guide_colorbar.py
@@ -104,7 +104,7 @@ class guide_colorbar(guide):
                 self.__class__.__name__,
             ]
         )
-        self.hash = hashlib.md5(info.encode("utf-8")).hexdigest()
+        self.hash = hashlib.sha256(info.encode("utf-8")).hexdigest()
         return self
 
     def merge(self, other):

--- a/plotnine/guides/guide_legend.py
+++ b/plotnine/guides/guide_legend.py
@@ -93,7 +93,7 @@ class guide_legend(guide):
         info = "\n".join(
             [self.title, labels, str(self.direction), self.__class__.__name__]
         )
-        self.hash = hashlib.md5(info.encode("utf-8")).hexdigest()
+        self.hash = hashlib.sha256(info.encode("utf-8")).hexdigest()
         return self
 
     def merge(self, other):


### PR DESCRIPTION
Currently plotnine uses `md5` which is disabled in FIPS-compliant environments:

![image](https://github.com/has2k1/plotnine/assets/1319049/58ebbdca-efb6-4894-93a1-028cd27bcb5d)

I've updated `md5` -> `sha256` to start the process of making the plotnine library FIPS-compliant.