### PR TITLE
Use string literal types in to_rgba() for matplotlib <3.8

### DIFF
--- a/plotnine/_utils/__init__.py
+++ b/plotnine/_utils/__init__.py
@@ -573,7 +573,6 @@ def to_rgba(
     However :), the colors can be rgba hex values or
     list-likes and the alpha dimension will be respected.
     """
-    from matplotlib.typing import ColorType
 
     def is_iterable(var):
         return np.iterable(var) and not isinstance(var, str)
@@ -608,7 +607,7 @@ def to_rgba(
         return c
 
     if is_iterable(colors):
-        colors = cast(Sequence[ColorType], colors)
+        colors = cast(Sequence["ColorType"], colors)
 
         if all(no_color(c) for c in colors):
             return "none"
@@ -618,7 +617,7 @@ def to_rgba(
         else:
             return [to_rgba_hex(c, alpha) for c in colors]
     else:
-        colors = cast(ColorType, colors)
+        colors = cast("ColorType", colors)
 
         if no_color(colors):
             return colors


### PR DESCRIPTION
Hi—thanks for the fresh 0.13.0 release and continued improvement of the package 🙏🏾

Today we saw errors like [this](https://github.com/khaeru/genno/actions/runs/7984260872/job/21800809579#step:6:1672) in GitHub Actions workflows that rely on plotnine, at this statement: https://github.com/has2k1/plotnine/blob/f5c01deb8e76e2fb9d0404a7fac527925276ac38/plotnine/_utils/__init__.py#L576

These boil down to the fact that (a) `matplotlib.typing` does not exist in matplotlib <3.8 but (b) plotnine is compatible with matplotlib >=3.6: https://github.com/has2k1/plotnine/blob/f5c01deb8e76e2fb9d0404a7fac527925276ac38/pyproject.toml#L26

In short:
```
$ pip list | grep -E "plotnine|matplotlib"
matplotlib                             3.7.0
matplotlib-inline                      0.1.6
plotnine                               0.13.0.post1+gf5c01deb            /home/khaeru/vc/u/has2k1/plotnine

$ python -c "from plotnine._utils import to_rgba; to_rgba(None, None)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/khaeru/vc/u/has2k1/plotnine/plotnine/_utils/__init__.py", line 576, in to_rgba
    from matplotlib.typing import ColorType
ModuleNotFoundError: No module named 'matplotlib.typing'
```

This one commit fixes by removing the import and using string literal types within the function. The type checker should then use ColorType as imported within the `if TYPE_CHECKING:` block at the top of the file.