### PR TITLE
Fix outdated documentation of `scale_color_cmap`

### DIFF
--- a/plotnine/scales/scale_color.py
+++ b/plotnine/scales/scale_color.py
@@ -455,7 +455,7 @@ class scale_color_cmap(scale_continuous):
         A standard Matplotlib colormap name. The default is
         `viridis`. For the list of names checkout the output
         of `matplotlib.colormaps()` or see the
-        [documentation](http://matplotlib.org/users/colormaps.html).
+        [documentation](https://matplotlib.org/stable/users/explain/colors/colormaps.html).
     {superclass_parameters}
     na_value : str, default="#7F7F7F"
         Color of missing values.

--- a/plotnine/scales/scale_color.py
+++ b/plotnine/scales/scale_color.py
@@ -454,8 +454,8 @@ class scale_color_cmap(scale_continuous):
     cmap_name :
         A standard Matplotlib colormap name. The default is
         `viridis`. For the list of names checkout the output
-        of `matplotlib.cm.cmap_d.keys()` or see the
-        `documentation <http://matplotlib.org/users/colormaps.html>`_.
+        of `matplotlib.colormaps()` or see the
+        [documentation](http://matplotlib.org/users/colormaps.html).
     {superclass_parameters}
     na_value : str, default="#7F7F7F"
         Color of missing values.


### PR DESCRIPTION
- `matplotlib.cm.cmap_d` was removed in matplotlib 3.9.0 (https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#removals)
- https://github.com/has2k1/plotnine/pull/706 migrated from RST to markdown but missed this link