### PR TITLE
fix: github workflow vulnerable to script injection

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+
 jobs:
   parse_commit_info:
     runs-on: ubuntu-latest
@@ -30,7 +33,7 @@ jobs:
           # The message string is directly substituted in before the command is run.
           # We use a HereDoc to avoid quotation issues if the message has quotes as well.
           TITLE=$(cat <<EOF | head -n 1
-          ${{ github.event.head_commit.message }}
+          $HEAD_COMMIT_MESSAGE
           EOF
           )
 


### PR DESCRIPTION
Hi! I'm Diogo from Google's Open Source Security Team([GOSST](https://opensource.googleblog.com/2023/04/googles-open-source-security-upstream-team-one-year-later.html)) and I'm dropping by to suggest this small change that will enhance the security of your repository by preventing script injection attacks through your GitHub workflows.

In the piece of code I changed, you were directly using the value of a variable that comes from a user's input, so a malicious user could exploit that input and use it to run arbitrary code. By using an intermediate environment variable, the value of the expression is stored in memory, used as a variable and doesn't interact with the script generation process. This mitigates the script injection risks and also keeps your workflow running exactly as before.

You can find more information about this on this [github documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) or in this [gitguardian blogpost](https://blog.gitguardian.com/github-actions-security-cheat-sheet/).

Cheers!