### PR TITLE
first attempt at strip_text_x ha adjustment for facets

### DIFF
--- a/plotnine/_mpl/text.py
+++ b/plotnine/_mpl/text.py
@@ -63,14 +63,31 @@ class StripText(Text):
         self.patch.set_transform(info.ax.transAxes)
         self.patch.set_mutation_scale(0)
 
+        info.ha = "right"
+        margin = 0.05
+
         # Put text in center of patch
-        self._x = l + w / 2
+        if isinstance(info.ha, str):
+            lookup = {
+                "left": 0.0,
+                "center": 0.5,
+                "right": 1.0,
+            }
+            f = lookup[info.ha]
+            anchor = info.ha
+            if anchor == "right":
+                margin = -margin
+        else:
+            f = info.ha
+            anchor = "left" if info.ha < 0.5 else "right"
+
+        self._x = l + (w * f) + (w * margin)
         self._y = b + h / 2
 
         # "anchor" aligns before rotation so the right-strip get properly
         # centered text
         self.set_rotation_mode("anchor")
-        self.set_horizontalalignment("center")  # right-strip
+        self.set_horizontalalignment(anchor)  # right-strip
         self.set_verticalalignment("center_baseline")  # top-strip
 
         # Draw spatch


### PR DESCRIPTION
For review. Current status:

- hard codes `info.ha` as e.g. `'right'` for testing purposes
- accepts 'left', 'center', and 'right' text args as well as float (matched approach [here](https://github.com/has2k1/plotnine/blob/4159f9548fa5f95c02366efc324e88f9ba79af09/plotnine/_mpl/_plotnine_tight_layout.py#L193-L240))
- `anchor` (justification) variable added and set to match `info.ha` (if str passed), or is 'left' if `ha < 0.5` else 'right'