### PR TITLE
add installation instructions for pixi

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ $ conda install -c conda-forge plotnine
 
 # Or using pixi
 $ pixi init name-of-my-project
+$ cd name-of-my-project
 $ pixi add python plotnine
 ```
 


### PR DESCRIPTION
adds installation instructions for [pixi](https://pixi.sh/) to README.md

Could you also point me to where the repo for the [guide](https://plotnine.org/guide/install.html) is?