### PR TITLE
TST: Fix plot composition test error messages

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,11 @@ ggplot.build_test = build_test
 
 
 def pytest_assertrepr_compare(op, left, right):
-    if isinstance(left, ggplot) and isinstance(right, str) and op == "==":
+    if (
+        isinstance(left, (ggplot, Compose))
+        and isinstance(right, str)
+        and op == "=="
+    ):
         msg = (
             "images not close: {actual:s} vs. {expected:s} "
             "(RMS {rms:.2f})".format(**left._err)
@@ -252,10 +256,10 @@ def composition_equals(cmp: Compose, name: str) -> bool:
     test_file = inspect.stack()[1][1]
     filenames = make_test_image_filenames(name, test_file)
 
-    cmp = cmp + theme(dpi=DPI)
+    _cmp = cmp + theme(dpi=DPI)
 
     with _test_cleanup():
-        cmp.save(filenames.result)
+        _cmp.save(filenames.result)
 
     if filenames.baseline.exists():
         shutil.copyfile(filenames.baseline, filenames.expected)


### PR DESCRIPTION
There are two issues:

1. We had not "opted" into the custom error messaging for the tests.
2. We have to be careful that we attach the result from compare_image to the original Compare instance (cmp._err) and not a copy of it.

closes #955