### PR TITLE
Fix is_knitr_engine check for quarto == 1.8.26

### DIFF
--- a/doc/changelog.qmd
+++ b/doc/changelog.qmd
@@ -17,6 +17,13 @@ title: Changelog
 
 - Fixed [](:class:`~plotnine.geom_smooth`) / [](:class:`~plotnine.stat_smooth`) when using a linear model via "lm" with weights for the model to do a weighted regression. This bug did not affect the formula API of the linear model. ({{< issue 1005 >}})
 
+## v0.15.2
+(2025-12-12)
+
+### Bug Fixes
+
+- Fixed random failures for when using plotnine in quarto == 1.8.26. {{< issue 1017 >}}
+
 ## v0.15.1
 (2025-09-30)
 

--- a/plotnine/_utils/quarto.py
+++ b/plotnine/_utils/quarto.py
@@ -47,8 +47,13 @@ def is_knitr_engine() -> bool:
         import json
         from pathlib import Path
 
-        info = json.loads(Path(filename).read_text())
-        return info["format"]["execute"]["engine"] == "knitr"
+        try:
+            info = json.loads(Path(filename).read_text())
+        except FileNotFoundError:
+            # NOTE: Remove this branch some time after quarto 1.9 is released
+            # https://github.com/quarto-dev/quarto-cli/issues/13613
+            return "rpytools" in sys.modules
+        return info["format"]["execute"].get("engine") == "knitr"
     else:
         # NOTE: Remove this branch some time after quarto 1.9 is released
         return "rpytools" in sys.modules


### PR DESCRIPTION
closes #1017
ref: quarto-dev/quarto-cli#13613