### PR TITLE
BUG: Deepcopy the plot saved as last_plot

### DIFF
--- a/plotnine/_utils/context.py
+++ b/plotnine/_utils/context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from copy import copy
+from copy import copy, deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -73,7 +73,7 @@ class plot_context:
         Enclose in matplolib & pandas environments
         """
 
-        self._last_plot = copy(self.plot)
+        self._last_plot = deepcopy(self.plot)
         self.rc_context.__enter__()
         if PANDAS_LT_3:
             self.pd_option_context.__enter__()


### PR DESCRIPTION
`plot_context` stored the in-progress plot via a shallow copy, so the object returned by `last_plot()` shared mutable nested state (e.g. the theme) with the plot being built. Building mutated that shared state, leaving `last_plot()` referencing a half-built plot.

As a result, code like

```python
last_plot() + labs(subtitle="ab")
```
failed to left-align the title, because the title's alignment had already been altered in the shared state during the previous build.

Use `deepcopy` so `last_plot()` is an independent, pristine snapshot.