### PR TITLE
feat: accept a scalar value in factor()

### DIFF
--- a/doc/changelog.qmd
+++ b/doc/changelog.qmd
@@ -91,6 +91,13 @@ title: Changelog
 
 ### Enhancements
 
+- The `factor` function available when evaluating expressions in
+  [](:class:`~plotnine.aes`) now accepts a scalar value.
+
+  ```python
+  ggplot(mtcars, aes("wt", "mpg", color="factor(4)")) + geom_point()
+  ```
+
 - Increased the default linespacing used by themes from `0.9` to `1.2`.
   This gives multiline titles, subtitles and captions a better balance between looking compact and looking crumpled.
 

--- a/plotnine/mapping/_eval_environment.py
+++ b/plotnine/mapping/_eval_environment.py
@@ -23,7 +23,7 @@ __all__ = (
 
 
 def factor(
-    values: Sequence[Any],
+    values: Sequence[Any] | float | str,
     categories: Sequence[Any] | None = None,
     ordered: bool | None = None,
 ) -> pd.Categorical:
@@ -48,6 +48,9 @@ def factor(
         `categories` attribute (which in turn is the `categories` argument, if
         provided).
     """
+    if isinstance(values, (int, float, str)):
+        values = [values]
+
     return pd.Categorical(values, categories=categories, ordered=None)  # pyright: ignore[reportReturnType]
 
 


### PR DESCRIPTION
A scalar (int, float or str) passed to factor() within an aes() expression is now wrapped in a list before creating the Categorical.