### PR TITLE
fix(facet): skip tick-label padding when axis text is blank

### DIFF
--- a/plotnine/facets/facet.py
+++ b/plotnine/facets/facet.py
@@ -350,11 +350,14 @@ class facet:
         ax.xaxis.set_major_formatter(MyFixedFormatter(panel_params.x.labels))
         ax.yaxis.set_major_formatter(MyFixedFormatter(panel_params.y.labels))
 
-        pad_x = theme.get_margin("axis_text_x").pt.t
-        pad_y = theme.get_margin("axis_text_y").pt.r
-
-        ax.tick_params(axis="x", which="major", pad=pad_x)
-        ax.tick_params(axis="y", which="major", pad=pad_y)
+        # Blank axis text is not drawn, so its margin may be absent
+        # (resolves to None). Skip the tick-label padding in that case.
+        if not theme.T.is_blank("axis_text_x"):
+            pad_x = theme.get_margin("axis_text_x").pt.t
+            ax.tick_params(axis="x", which="major", pad=pad_x)
+        if not theme.T.is_blank("axis_text_y"):
+            pad_y = theme.get_margin("axis_text_y").pt.r
+            ax.tick_params(axis="y", which="major", pad=pad_y)
 
     def __deepcopy__(self, memo: dict[Any, Any]) -> facet:
         """

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -337,3 +337,11 @@ def test_override_axis_text():
     )
 
     assert p == "override_axis_text"
+
+
+def test_blank_all_text_draws():
+    # Blanking the base `text` element removes every specific text
+    # themeable, so axis_text_x/_y margins resolve to None. Drawing must
+    # not crash when computing the tick-label padding. (Regression)
+    p = ggplot() + lims(x=(0, 100), y=(0, 100)) + theme(text=element_blank())
+    p.draw_test()  # pyright: ignore  # must not raise


### PR DESCRIPTION
`theme(text=element_blank())` removes the specific axis-text themeables, so `theme.get_margin('axis_text_x')` resolves to None and led to an exception.

Solution is to guard each axis with `theme.T.is_blank(...)`.