### PR TITLE
Removed copy call from mpl.rcParams for params update when using defaults.

### DIFF
--- a/plotnine/themes/theme_matplotlib.py
+++ b/plotnine/themes/theme_matplotlib.py
@@ -136,7 +136,7 @@ class theme_matplotlib(theme):
         )
 
         if use_defaults:
-            self._rcParams.update(mpl.rcParams.copy())
+            self._rcParams.update(mpl.rcParams)
 
         if fname:
             self._rcParams.update(mpl.rc_params_from_file(fname))


### PR DESCRIPTION
The copy method for Matplotlib's rcParams creates a raw copy without resolving the backend. Calling update directly on the default rcParams causes the backend to resolve before copying the value over.

Closes #1071