### PR TITLE
Fix: missing f-marker on facet-scales-error-message

### DIFF
--- a/plotnine/facets/facet.py
+++ b/plotnine/facets/facet.py
@@ -122,7 +122,7 @@ class facet:
         allowed_scales = ["fixed", "free", "free_x", "free_y"]
         if scales not in allowed_scales:
             raise ValueError(
-                "Argument `scales` must be one of {allowed_scales}."
+                f"Argument `scales` must be one of {allowed_scales}."
             )
         self.free = {
             "x": scales in ("free_x", "free"),


### PR DESCRIPTION
Noticed this error message literally printing "Argument `scales` must be one of {allowed_scales}."',
instead of stamping in the allowed values.

Pretty sure I messed that up last year, my apologies.