### PR TITLE
Compute axis band per-side, drop 'moved axis'

### DIFF
--- a/plotnine/_mpl/layout_manager/_plot_side_space.py
+++ b/plotnine/_mpl/layout_manager/_plot_side_space.py
@@ -143,24 +143,20 @@ class _plot_side_space(_side_space):
             raise PlotnineError("Side has no axis title") from err
 
     @property
-    def _axis_primary_extent(self) -> float:
+    def _axis_ticks_and_text(self) -> float:
         """
-        Outward extent of a moved axis's ticks and tick labels, figure space
+        Outward extent of this side's axis ticks and tick labels, figure space
 
-        This is the part of a moved axis that sits next to the panel; the
-        axis title is excluded. Zero on sides whose axis is in its default
-        position.
+        The axis title is excluded. Computed from the items present on the
+        side, identically for all four sides; zero on a side with no axis.
         """
-        return 0
-
-    # Typed default so strip_band_offset type-checks; concrete sides redeclare.
-    strip_text: float = 0
+        return self.sum_incl("axis_ticks") - self.sum_upto("axis_text")
 
     def strip_band_offset(self, member: Literal["strip", "axis"]) -> float:
         """
         Outward offset for one member of a shared strip/axis band
 
-        When a moved axis and a facet strip occupy the same side, the band is
+        When a facet strip and an axis occupy the same side, the band is
         ordered from the panel outward. `strip_placement` chooses the order:
 
             "inside":   panel | strip | ticks+labels | title
@@ -171,20 +167,17 @@ class _plot_side_space(_side_space):
         consumed per artist in its own coordinate system: the title in figure
         space, the tick labels in axes fractions, the spine in points.
 
-        The offset is zero unless the side has both a strip and a moved axis.
-        Bottom/left sides leave `_axis_primary_extent` at zero (a strip there
-        would share the side with the *default* axis, which the facet API does
-        not yet expose), so this returns zero for them.
+        The offset is zero unless the side carries both a strip and an axis.
         """
-        strip = self.strip_text
-        primary = self._axis_primary_extent
-        if not (strip and primary):
+        strip_breadth: float = self.strip_text  # pyright: ignore[reportAttributeAccessIssue]
+        axis_breadth = self._axis_ticks_and_text
+        if not (strip_breadth and axis_breadth):
             return 0
         placement = self.items.plot.theme.getp("strip_placement")
         if placement == "inside":
-            return 0 if member == "strip" else strip
+            return 0 if member == "strip" else strip_breadth
         # "outside"
-        return primary if member == "strip" else 0
+        return axis_breadth if member == "strip" else 0
 
 
 class left_space(_plot_side_space):
@@ -436,10 +429,6 @@ class right_space(_plot_side_space):
             self.plot_margin += adjustment
 
     @property
-    def _axis_primary_extent(self) -> float:
-        return self.sum_incl("axis_ticks") - self.sum_upto("axis_text")
-
-    @property
     def axis_title_clearance(self) -> float:
         """
         Axis-title-to-panel clearance, excluding any facet strip
@@ -599,10 +588,6 @@ class top_space(_plot_side_space):
         adjustment = protrusion - (self.total - self.plot_margin)
         if adjustment > 0:
             self.plot_margin += adjustment
-
-    @property
-    def _axis_primary_extent(self) -> float:
-        return self.sum_incl("axis_ticks") - self.sum_upto("axis_text")
 
     @property
     def axis_title_clearance(self) -> float:


### PR DESCRIPTION
The strip/axis coexistence logic (`strip_placement`) decided when a strip and an axis collide by asking whether the axis had been moved — its `scale.position` differing from the default _bottom/left_. That worked only by coincidence: strips default to _top/right_ and axes to _bottom/left_, so the one way they could share a side today was for the axis to be moved.

The coincidence isn't load-bearing. The moment strips are allowed off the top/right — e.g. a future `facet_wrap(strip_position="bottom")`, the offset logic silently no-ops, and the strip overlaps the axis.

The deeper issue: the layout manager had encoded a default-position assumption it has no business knowing. Layout is geometry. A side has some strip extent and some axis extent; it orders and offsets them. How the axis got there is upstream knowledge that must not reach the layout manager.