### PR TITLE
fix(layer): cast polars decimal columns to float

### DIFF
--- a/plotnine/layer.py
+++ b/plotnine/layer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import decimal
 import typing
 from copy import copy, deepcopy
 from typing import Iterable, List, cast, overload
@@ -29,6 +30,23 @@ if typing.TYPE_CHECKING:
         DataLike,
         LayerDataLike,
     )
+
+
+def _convert_decimal_columns(data: pd.DataFrame) -> pd.DataFrame:
+    """
+    Cast columns of decimal.Decimal values to float
+
+    polars' `to_pandas()` maps a Decimal column onto a pandas object column
+    holding `decimal.Decimal` values. plotnine treats object columns as
+    discrete, so such a column cannot be used with a continuous scale. Casting
+    it to float lets it behave like any other numeric column.
+    """
+    for col in data.columns:
+        if data[col].dtype == object:
+            non_null = data[col].dropna()
+            if len(non_null) and isinstance(non_null.iloc[0], decimal.Decimal):
+                data[col] = data[col].astype("float64")
+    return data
 
 
 class layer:
@@ -222,7 +240,9 @@ class layer:
         if plot_data is None:
             data = pd.DataFrame()
         elif hasattr(plot_data, "to_pandas"):
-            data = cast("DataFrameConvertible", plot_data).to_pandas()
+            data = _convert_decimal_columns(
+                cast("DataFrameConvertible", plot_data).to_pandas()
+            )
         else:
             data = cast("pd.DataFrame", plot_data)
 
@@ -249,9 +269,9 @@ class layer:
         else:
             # Recognise polars dataframes
             if hasattr(self._data, "to_pandas"):
-                self.data = cast(
-                    "DataFrameConvertible", self._data
-                ).to_pandas()
+                self.data = _convert_decimal_columns(
+                    cast("DataFrameConvertible", self._data).to_pandas()
+                )
             elif isinstance(self._data, pd.DataFrame):
                 self.data = self._data.copy()
             else:

--- a/plotnine/layer.py
+++ b/plotnine/layer.py
@@ -32,23 +32,6 @@ if typing.TYPE_CHECKING:
     )
 
 
-def _convert_decimal_columns(data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Cast columns of decimal.Decimal values to float
-
-    polars' `to_pandas()` maps a Decimal column onto a pandas object column
-    holding `decimal.Decimal` values. plotnine treats object columns as
-    discrete, so such a column cannot be used with a continuous scale. Casting
-    it to float lets it behave like any other numeric column.
-    """
-    for col in data.columns:
-        if data[col].dtype == object:
-            non_null = data[col].dropna()
-            if len(non_null) and isinstance(non_null.iloc[0], decimal.Decimal):
-                data[col] = data[col].astype("float64")
-    return data
-
-
 class layer:
     """
     Layer
@@ -240,9 +223,7 @@ class layer:
         if plot_data is None:
             data = pd.DataFrame()
         elif hasattr(plot_data, "to_pandas"):
-            data = _convert_decimal_columns(
-                cast("DataFrameConvertible", plot_data).to_pandas()
-            )
+            data = cast("DataFrameConvertible", plot_data).to_pandas()
         else:
             data = cast("pd.DataFrame", plot_data)
 
@@ -269,13 +250,15 @@ class layer:
         else:
             # Recognise polars dataframes
             if hasattr(self._data, "to_pandas"):
-                self.data = _convert_decimal_columns(
-                    cast("DataFrameConvertible", self._data).to_pandas()
-                )
+                self.data = cast(
+                    "DataFrameConvertible", self._data
+                ).to_pandas()
             elif isinstance(self._data, pd.DataFrame):
                 self.data = self._data.copy()
             else:
                 raise TypeError(f"Data has a bad type: {type(self.data)}")
+
+        self.data = _decimal_columns_to_float(self.data)
 
     def _make_layer_mapping(self, plot_mapping: aes):
         """
@@ -798,3 +781,27 @@ def _resolve_position(
         raise PlotnineError(f"Unknown position of type {type(position_spec)}")
 
     return klass()
+
+
+def _decimal_columns_to_float(data: pd.DataFrame) -> pd.DataFrame:
+    """
+    Cast columns of decimal.Decimal values to float
+
+    polars' `to_pandas()` maps a Decimal column onto a pandas object column
+    holding `decimal.Decimal` values. plotnine treats object columns as
+    discrete, so such a column cannot be used with a continuous scale. Casting
+    it to float lets it behave like any other numeric column.
+
+    This runs for every dataframe, so we avoid the expense of `.dropna()`
+    (which builds a filtered copy) and use a mask to peek at the first
+    non-null value instead.
+    """
+    for col in data.columns:
+        series = data[col]
+        if series.dtype == object:
+            mask = series.notna()
+            if mask.any() and isinstance(
+                series[mask.idxmax()], decimal.Decimal
+            ):
+                data[col] = series.astype("float64")
+    return data

--- a/tests/test_ggplot_internals.py
+++ b/tests/test_ggplot_internals.py
@@ -12,6 +12,7 @@ from plotnine import (
     coord_trans,
     facet_null,
     geom_bar,
+    geom_col,
     geom_histogram,
     geom_line,
     geom_point,
@@ -21,6 +22,7 @@ from plotnine import (
     labs,
     lims,
     scale_x_continuous,
+    scale_y_continuous,
     stage,
     stat_identity,
     theme,
@@ -363,6 +365,29 @@ def test_to_pandas():
     p2 = data >> ggplot(aes("x", "y")) + geom_point()
     assert p1 == "to_pandas"
     assert p2 == "to_pandas"
+
+
+def test_to_pandas_decimal_columns():
+    # polars' to_pandas() returns a Decimal column as an object column of
+    # decimal.Decimal values, which would otherwise be treated as discrete
+    # and rejected by a continuous scale. See GH #1033.
+    from decimal import Decimal
+
+    class DecimalData:
+        def to_pandas(self):
+            return pd.DataFrame(
+                {
+                    "x": ["a", "b", "c"],
+                    "y": [Decimal(1), Decimal(2), Decimal(3)],
+                }
+            )
+
+    p = (
+        ggplot(DecimalData(), aes("x", "y"))
+        + geom_col()
+        + scale_y_continuous(limits=(0, 5))
+    )
+    p._build()
 
 
 def test_callable_as_data():

--- a/tests/test_ggplot_internals.py
+++ b/tests/test_ggplot_internals.py
@@ -367,23 +367,20 @@ def test_to_pandas():
     assert p2 == "to_pandas"
 
 
-def test_to_pandas_decimal_columns():
-    # polars' to_pandas() returns a Decimal column as an object column of
-    # decimal.Decimal values, which would otherwise be treated as discrete
-    # and rejected by a continuous scale. See GH #1033.
+def test_decimal_columns():
+    # A pandas object column of decimal.Decimal values (e.g. from polars'
+    # to_pandas()) would otherwise be treated as discrete and rejected by a
+    # continuous scale. See GH #1033.
     from decimal import Decimal
 
-    class DecimalData:
-        def to_pandas(self):
-            return pd.DataFrame(
-                {
-                    "x": ["a", "b", "c"],
-                    "y": [Decimal(1), Decimal(2), Decimal(3)],
-                }
-            )
-
+    data = pd.DataFrame(
+        {
+            "x": ["a", "b", "c"],
+            "y": [Decimal(1), Decimal(2), Decimal(3)],
+        }
+    )
     p = (
-        ggplot(DecimalData(), aes("x", "y"))
+        ggplot(data, aes("x", "y"))
         + geom_col()
         + scale_y_continuous(limits=(0, 5))
     )


### PR DESCRIPTION
A polars Decimal column comes through to_pandas() as a pandas object column of decimal.Decimal values, so plotnine reads it as discrete and a continuous scale rejects it with "Discrete value supplied to continuous scale" (#1033). This casts those Decimal object columns to float right after the conversion, following the cheap-hack approach you mentioned in the issue, so such a column now behaves like any other numeric one instead of needing a manual cast to Float. I added a small regression test that builds a plot from a Decimal column on a continuous scale. Thanks!