### PR TITLE
fix: correct typos in docstrings and comments

### DIFF
--- a/plotnine/_mpl/layout_manager/_composition_side_space.py
+++ b/plotnine/_mpl/layout_manager/_composition_side_space.py
@@ -452,7 +452,7 @@ class CompositionSideSpaces:
         Apply the space calculations to the sub_gridspec
 
         After calling this method, the sub_gridspec will be appropriately
-        sized to accomodate the content of the annotations.
+        sized to accommodate the content of the annotations.
         """
         gsparams = self.calculate_gridspec_params()
         self.sub_gridspec.update_params_and_artists(gsparams)

--- a/plotnine/_mpl/layout_manager/_plot_layout_items.py
+++ b/plotnine/_mpl/layout_manager/_plot_layout_items.py
@@ -1096,7 +1096,7 @@ def _position_legends(
 
 def _position_plot_tag(tag: Text, spaces: PlotSideSpaces):
     """
-    Set the postion of the plot_tag
+    Set the position of the plot_tag
     """
     theme = spaces.plot.theme
     panels_gs = spaces.plot._sub_gridspec

--- a/plotnine/_mpl/layout_manager/_plot_side_space.py
+++ b/plotnine/_mpl/layout_manager/_plot_side_space.py
@@ -1002,7 +1002,7 @@ class PlotSideSpaces:
         Apply the space calculations to the sub_gridspec
 
         After calling this method, the sub_gridspec will be appropriately
-        sized to accomodate the artists around the panels.
+        sized to accommodate the artists around the panels.
         """
         gsparams = self.calculate_gridspec_params()
         self.sub_gridspec.update_params_and_artists(gsparams)

--- a/plotnine/_mpl/utils.py
+++ b/plotnine/_mpl/utils.py
@@ -405,7 +405,7 @@ class TextJustifier:
         self, text: Text, ha: HorizontalJustification | float
     ):
         """
-        Horizontally Justify text accross the panel(s) width
+        Horizontally Justify text across the panel(s) width
         """
         self.horizontally(
             text, ha, self.boundaries.panel_left, self.boundaries.panel_right

--- a/plotnine/facets/labelling.py
+++ b/plotnine/facets/labelling.py
@@ -132,7 +132,7 @@ def as_labeller(
     multi_line: bool = True,
 ) -> labeller:
     """
-    Coerse to labeller
+    Coerce to labeller
 
     Parameters
     ----------

--- a/plotnine/scales/scale_datetime.py
+++ b/plotnine/scales/scale_datetime.py
@@ -65,7 +65,7 @@ class scale_datetime(scale_continuous):
     - `(0, timedelta(days=1))` - Expand lower and upper limits by 1 day.
     - `(1, 0)` - Expand lower and upper limits by 100%.
     - `(0, 0, 0, timedelta(hours=6))` - Expand upper limit by 6 hours.
-    - `(0, timedelta(minutes=5), 0.1, timdelta(0))` - Expand lower limit
+    - `(0, timedelta(minutes=5), 0.1, timedelta(0))` - Expand lower limit
       by 5 minutes and upper limit by 10%.
     - `(0, 0, 0.1, timedelta(weeks=2))` - Expand upper limit by 10% plus
       2 weeks.

--- a/plotnine/stats/stat_qq.py
+++ b/plotnine/stats/stat_qq.py
@@ -95,7 +95,7 @@ def theoretical_qq(
     distribution_params: dict[str, Any],
 ) -> FloatArray:
     """
-    Caculate theoretical qq distribution
+    Calculate theoretical qq distribution
     """
     from scipy.stats.mstats import plotting_positions
 

--- a/plotnine/themes/theme.py
+++ b/plotnine/themes/theme.py
@@ -305,7 +305,7 @@ class theme:
 
     def get_margin(self, name: str) -> margin:
         """
-        Return the margin propery of a element_text themeables
+        Return the margin property of a element_text themeables
         """
         return self.themeables.getp((name, "margin"))
 

--- a/plotnine/themes/themeable.py
+++ b/plotnine/themes/themeable.py
@@ -386,7 +386,7 @@ class Themeables(dict[str, themeable]):
 
     def get_ha(self, name: str) -> float:
         """
-        Get the horizontal alignement of themeable as a float
+        Get the horizontal alignment of themeable as a float
 
         The themeable should be and element_text
         """
@@ -398,7 +398,7 @@ class Themeables(dict[str, themeable]):
 
     def get_va(self, name) -> float:
         """
-        Get the vertical alignement of themeable as a float
+        Get the vertical alignment of themeable as a float
 
         The themeable should be and element_text
         """


### PR DESCRIPTION
Fixes 10 spelling errors found across docstrings and inline comments in source files. None are in generated files, changelogs, fixtures, or test data.

## Changes

| File | Typo | Correction |
|------|------|------------|
| `plotnine/facets/labelling.py` | `Coerse` | `Coerce` |
| `plotnine/_mpl/utils.py` | `accross` | `across` |
| `plotnine/_mpl/layout_manager/_composition_side_space.py` | `accomodate` | `accommodate` |
| `plotnine/_mpl/layout_manager/_plot_layout_items.py` | `postion` | `position` |
| `plotnine/_mpl/layout_manager/_plot_side_space.py` | `accomodate` | `accommodate` |
| `plotnine/scales/scale_datetime.py` | `timdelta` | `timedelta` |
| `plotnine/stats/stat_qq.py` | `Caculate` | `Calculate` |
| `plotnine/themes/theme.py` | `propery` | `property` |
| `plotnine/themes/themeable.py` | `alignement` | `alignment` (x2) |

All fixes are in docstrings or comments only - no logic or identifier changes.