### PR TITLE
Fix argument order in scale_size_datetime.__post_init__

### DIFF
--- a/doc/changelog.qmd
+++ b/doc/changelog.qmd
@@ -112,6 +112,10 @@ title: Changelog
 
 ### Bug Fixes
 
+- [](:class:`~plotnine.scale_size_datetime`) no longer raises an error (or
+  silently ignores `date_breaks`); its `__post_init__` parameters were
+  declared in the wrong order, misrouting the `range` argument.
+
 - In a non-linear coordinate system (e.g. [](:class:`~plotnine.coord_trans`)),
   the closing edge of a polygon is now curved along with the rest of its
   boundary instead of being drawn as a straight chord.

--- a/doc/changelog.qmd
+++ b/doc/changelog.qmd
@@ -112,9 +112,12 @@ title: Changelog
 
 ### Bug Fixes
 
-- [](:class:`~plotnine.scale_size_datetime`) no longer raises an error (or
-  silently ignores `date_breaks`); its `__post_init__` parameters were
-  declared in the wrong order, misrouting the `range` argument.
+- [](:class:`~plotnine.scale_size_datetime`) now honours its `range`
+  argument. Previously it was ignored and mapping data raised an error.
+
+- [](:class:`~plotnine.scale_size_datetime`) now honours its `date_breaks`,
+  `date_labels` and `date_minor_breaks` arguments, which it previously
+  ignored.
 
 - In a non-linear coordinate system (e.g. [](:class:`~plotnine.coord_trans`)),
   the closing edge of a polygon is now curved along with the rest of its

--- a/plotnine/scales/scale_size.py
+++ b/plotnine/scales/scale_size.py
@@ -141,7 +141,7 @@ class scale_size_datetime(scale_datetime):
     guide: OptionalLegend = "legend"
 
     def __post_init__(
-        self, range, date_breaks, date_labels, date_minor_breaks
+        self, date_breaks, date_labels, date_minor_breaks, range
     ):
         from mizani.palettes import area_pal
 

--- a/plotnine/scales/scale_size.py
+++ b/plotnine/scales/scale_size.py
@@ -141,7 +141,11 @@ class scale_size_datetime(scale_datetime):
     guide: OptionalLegend = "legend"
 
     def __post_init__(
-        self, date_breaks, date_labels, date_minor_breaks, range
+        self,
+        date_breaks: str | None,
+        date_labels: str | None,
+        date_minor_breaks: str | None,
+        range: tuple[float, float],
     ):
         from mizani.palettes import area_pal
 

--- a/tests/test_scale_internals.py
+++ b/tests/test_scale_internals.py
@@ -45,6 +45,7 @@ from plotnine.scales.scale_shape import (
 from plotnine.scales.scale_size import (
     scale_size_area,
     scale_size_continuous,
+    scale_size_datetime,
     scale_size_discrete,
     scale_size_radius,
 )
@@ -248,6 +249,17 @@ def test_size_palette():
 
     s = scale_size_radius(range=(1, 6))
     s.palette(frac**2)
+
+
+def test_size_datetime_palette():
+    # The `range` argument must reach the area palette. Regression: the
+    # __post_init__ InitVars were declared in the wrong order, so `range`
+    # was misrouted and the palette crashed / ignored it.
+    s = scale_size_datetime(range=(2, 10))
+    npt.assert_allclose(s.palette([0.0, 1.0]), [2.0, 10.0])
+
+    s = scale_size_datetime()
+    npt.assert_allclose(s.palette([0.0, 1.0]), [1.0, 6.0])
 
 
 def test_scale_identity():

--- a/tests/test_scale_internals.py
+++ b/tests/test_scale_internals.py
@@ -251,15 +251,26 @@ def test_size_palette():
     s.palette(frac**2)
 
 
-def test_size_datetime_palette():
-    # The `range` argument must reach the area palette. Regression: the
-    # __post_init__ InitVars were declared in the wrong order, so `range`
-    # was misrouted and the palette crashed / ignored it.
-    s = scale_size_datetime(range=(2, 10))
+def test_size_datetime_arguments():
+    # Every initialisation-only argument is checked, not just `range`. They
+    # reach the scale by position, so one of them landing in the wrong
+    # parameter leaves the others correct and the mistake invisible.
+    s = scale_size_datetime(
+        date_breaks="1 year",
+        date_labels="%Y",
+        date_minor_breaks="1 month",
+        range=(2, 10),
+    )
     npt.assert_allclose(s.palette([0.0, 1.0]), [2.0, 10.0])
+    assert callable(s.breaks)
+    assert callable(s.labels)
+    assert callable(s.minor_breaks)
 
     s = scale_size_datetime()
     npt.assert_allclose(s.palette([0.0, 1.0]), [1.0, 6.0])
+    assert s.breaks is True
+    assert s.labels is True
+    assert s.minor_breaks is True
 
 
 def test_scale_identity():


### PR DESCRIPTION
### Summary

`scale_size_datetime` is a `@dataclass` subclass of `scale_datetime`, so the generated `__init__` passes the `InitVar` pseudo-fields to `__post_init__` **positionally, in field order** — base class first: `(date_breaks, date_labels, date_minor_breaks, range)`.

But `__post_init__` declares them in a different order:

```python
def __post_init__(
    self, range, date_breaks, date_labels, date_minor_breaks   # transposed
):
    ...
    self.palette = area_pal(range)
```

So `range` receives the `date_breaks` value, `date_breaks` receives `date_labels`, etc. — every argument is misrouted.

### Reproduce

```python
from plotnine.scales.scale_size import scale_size_datetime

s = scale_size_datetime(range=(2, 10))
s.palette([0, 0.5, 1.0])      # ValueError: object of too small depth for desired array
```

- `range=(2, 10)` is misrouted into `date_minor_breaks`; the real `range` local becomes `None`, so `area_pal(None)` is built and crashes when mapping.
- `scale_size_datetime(date_breaks="1 year")` misroutes `"1 year"` into `range`, so the user's `date_breaks` is silently dropped.

The sibling datetime scales all declare these InitVars correctly — e.g. `scale_alpha_datetime.__post_init__(self, date_breaks, date_labels, date_minor_breaks, range)`.

### Fix

Reorder the parameters to match the field order (the body was already correct):

```python
def __post_init__(
    self, date_breaks, date_labels, date_minor_breaks, range
):
```

After the fix, `scale_size_datetime(range=(2, 10)).palette([0.0, 1.0])` returns `[2.0, 10.0]`, defaults give `[1.0, 6.0]`, and `date_breaks` is honored.

### Tests

Added `test_size_datetime_palette`, which constructs the scale with `range=` and asserts the palette endpoints. It fails on `main` (`ValueError`) and passes with the fix. `pytest tests/test_scale_internals.py -k size` → passes. Added a changelog entry.