### PR TITLE
Fix typos in docstrings

### DIFF
--- a/plotnine/stats/stat_bin.py
+++ b/plotnine/stats/stat_bin.py
@@ -25,7 +25,7 @@ class stat_bin(stat):
     ----------
     {common_parameters}
     binwidth : float, default=None
-        The width of the bins. The default is to use bins bins that
+        The width of the bins. The default is to use bins that
         cover the range of the data. You should always override this
         value, exploring multiple widths to find the best to illustrate
         the stories in your data.

--- a/plotnine/stats/stat_bin_2d.py
+++ b/plotnine/stats/stat_bin_2d.py
@@ -29,7 +29,7 @@ class stat_bin_2d(stat):
         a list of two array_likes to provide distinct breaks for
         the `x` and `y` axes.
     binwidth : float, default=None
-        The width of the bins. The default is to use bins bins that
+        The width of the bins. The default is to use bins that
         cover the range of the data. You should always override this
         value, exploring multiple widths to find the best to illustrate
         the stories in your data.

--- a/plotnine/stats/stat_ellipse.py
+++ b/plotnine/stats/stat_ellipse.py
@@ -149,9 +149,9 @@ def cov_trob(
     Returns
     -------
     out : dict
-        A dictionary with with the following key-value
+        A dictionary with the following key-value
 
-        - `cov` : the fitted covarince matrix.
+        - `cov` : the fitted covariance matrix.
         - `center` : the estimated or specified location vector.
         - `wt` : the specified weights: only returned if the
            wt argument was given.

--- a/plotnine/stats/stat_summary_bin.py
+++ b/plotnine/stats/stat_summary_bin.py
@@ -26,7 +26,7 @@ class stat_summary_bin(stat):
     ----------
     {common_parameters}
     binwidth : float | tuple, default=None
-        The width of the bins. The default is to use bins bins that
+        The width of the bins. The default is to use bins that
         cover the range of the data. You should always override this
         value, exploring multiple widths to find the best to illustrate
         the stories in your data.

--- a/plotnine/themes/theme.py
+++ b/plotnine/themes/theme.py
@@ -403,7 +403,7 @@ class theme:
 
         Notes
         -----
-        Subclasses should not need to override this method method as long as
+        Subclasses should not need to override this method as long as
         self._rcParams is constructed properly.
 
         rcParams are used during plotting. Sometimes the same theme can be

--- a/plotnine/themes/theme_light.py
+++ b/plotnine/themes/theme_light.py
@@ -7,7 +7,7 @@ class theme_light(theme_gray):
     """
     A theme similar to [](`~plotnine.themes.theme_linedraw.theme_linedraw`)
 
-    Has light grey lines lines and axes to direct more attention
+    Has light grey lines and axes to direct more attention
     towards the data.
 
     Parameters


### PR DESCRIPTION
A few small typos in docstrings:

- `plotnine/stats/stat_bin.py`, `stat_bin_2d.py`, `stat_summary_bin.py`: "to use bins bins that" -> "to use bins that".
- `plotnine/stats/stat_ellipse.py`: "A dictionary with with the following" -> "with the following"; and "the fitted covarince matrix" -> "covariance".
- `plotnine/themes/theme_light.py`: "light grey lines lines and axes" -> "lines and axes".
- `plotnine/themes/theme.py`: "override this method method as long as" -> "this method as long as".

Documentation only.
