### PR TITLE
Honour the dpi when saving a composition

### DIFF
--- a/doc/changelog.qmd
+++ b/doc/changelog.qmd
@@ -190,6 +190,10 @@ title: Changelog
   prevented layout from reserving their space, so the labels could render
   outside the figure.
 
+- Saving a composition now honours the `dpi` argument. For example,
+  `(p1 | p2).save("composition.png", dpi=200)` saves the image at 200 DPI
+  instead of the default resolution.
+
 ### Enhancements
 
 - The `factor` function available when evaluating expressions in

--- a/plotnine/composition/_compose.py
+++ b/plotnine/composition/_compose.py
@@ -842,19 +842,26 @@ class Compose:
             Image format to use, automatically extract from
             file name extension.
         dpi :
-            DPI to use for raster graphics. If None, defaults to using
-            the `dpi` of theme to the first plot.
+            DPI for raster graphics. If `None`, use the composition theme's
+            `dpi`.
         **kwargs :
             These are ignored. Here to "softly" match the API of
             `ggplot.save()`.
         """
         from plotnine import theme
 
-        # To set the dpi, we only need to change the dpi of
-        # the last plot and theme gets added to the last plot
-        plot = (self + theme(dpi=dpi)) if dpi else self
-        figure = plot.draw()
-        figure.savefig(filename, format=format)
+        # Set the composition theme's DPI because the composition owns the
+        # figure. Inner plots inherit this value.
+        cmp = self
+        if dpi:
+            cmp = deepcopy(self)
+            cmp.theme = cmp.theme + theme(dpi=dpi)
+
+        figure = cmp.draw()
+
+        # Pass the DPI explicitly so `savefig.dpi` cannot override the
+        # requested resolution.
+        figure.savefig(filename, format=format, dpi=figure.get_dpi())
 
 
 def _renders_legend_inside(t: theme) -> bool:

--- a/tests/test_plot_composition.py
+++ b/tests/test_plot_composition.py
@@ -1,4 +1,7 @@
+from io import BytesIO
+
 import pytest
+from PIL import Image
 
 from plotnine import (
     element_line,
@@ -469,3 +472,16 @@ def test_spacer_first_plus_plot():
     # Putting the spacer on the LHS exercises plot_spacer.__add__.
     p = plot_spacer() + plot.red
     assert p == "spacer_first_plus_plot"
+
+
+def test_save_honours_requested_dpi():
+    # The composition owns the figure, so setting the DPI only on an inner
+    # plot cannot change the saved image dimensions.
+    cmp = plot.red | plot.green
+    width, height = cmp.theme.getp("figure_size")
+
+    for dpi in (100, 200):
+        buf = BytesIO()
+        cmp.save(buf, format="png", dpi=dpi)
+        expected = (int(width * dpi), int(height * dpi))
+        assert Image.open(buf).size == expected


### PR DESCRIPTION
Saving a composition ignored the `dpi` argument and wrote the image at the default resolution.

```python
p1 = ggplot(mtcars, aes("wt", "mpg")) + geom_point()
p2 = ggplot(mtcars, aes("wt", "hp")) + geom_point()

# 640 x 480 pixels, before and after asking for 200 dpi
(p1 | p2).save("composition.png", dpi=200)
# The image is now 1280 x 960
```

