### PR TITLE
Preserve path breaks during interpolation

### DIFF
--- a/doc/changelog.qmd
+++ b/doc/changelog.qmd
@@ -144,6 +144,17 @@ title: Changelog
   rectangle is now drawn as its own polygon instead of merging a bar's
   segments into a single path.
 
+- Under a non-linear coordinate system such as
+  [](:class:`~plotnine.coord_trans`), a [](:class:`~plotnine.geom_polygon`)
+  with several groups no longer draws an edge from one polygon to the next.
+
+- Under a non-linear coordinate system, separate
+  [](:class:`~plotnine.geom_path`) groups no longer connect when an aesthetic
+  such as `color` varies along the path. The fix also applies to
+  [](:class:`~plotnine.geom_line`), [](:class:`~plotnine.geom_step`),
+  [](:class:`~plotnine.geom_density`) and the line drawn by
+  [](:class:`~plotnine.geom_smooth`).
+
 - In a non-linear coordinate system (e.g. [](:class:`~plotnine.coord_trans`)),
   both edges of a [](:class:`~plotnine.geom_ribbon`) or
   [](:class:`~plotnine.geom_area`) now curve. Previously each edge held the

--- a/plotnine/coords/coord.py
+++ b/plotnine/coords/coord.py
@@ -460,9 +460,13 @@ def munch_data(data: pd.DataFrame, dist: FloatArray) -> pd.DataFrame:
     """
     segment_length = 0.01
 
-    # Count new points per segment, excluding the final endpoint.
-    dist[np.isnan(dist)] = 1
-    extra = np.maximum(np.floor(dist / segment_length), 1)
+    # Count new points per segment, excluding the final endpoint. `dist` is
+    # `NaN` at a path break. Give a break only its starting point;
+    # interpolation would connect the paths on either side.
+    is_break = np.isnan(dist)
+    extra = np.maximum(
+        np.floor(np.where(is_break, 0, dist) / segment_length), 1
+    )
     extra = extra.astype(int)
 
     # Every position aesthetic defines path geometry. Replicating `ymin` and

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -115,6 +115,21 @@ def test_munch_interpolates_every_position_aesthetic():
         assert np.all(np.diff(values) > 0), f"{column} was not interpolated"
 
 
+def test_munch_data_preserves_a_flagged_break():
+    # A `NaN` distance marks a break between paths. The marked segment
+    # keeps only its starting point because interpolation would connect
+    # the paths on either side.
+    data = pd.DataFrame(
+        {"x": [0.0, 1.0, 2.0], "y": [0.0, 1.0, 2.0], "group": [1, 1, 1]}
+    )
+
+    munched = munch_data(data, np.array([np.nan, 1.0]))
+
+    flagged_segment = munched[munched["x"] < 1.0]
+    assert len(flagged_segment) == 1
+    assert flagged_segment["x"].iloc[0] == 0.0
+
+
 def test_coord_trans_ribbon_edges_curve():
     # A smooth transformed ribbon exposes piecewise-constant `ymin` and
     # `ymax` values as stepped edges.


### PR DESCRIPTION
Under a non-linear coordinate system, a `geom_polygon` with several groups draws an edge from one polygon to the next, and separate `geom_path` groups join up when an aesthetic varies along the line.

```python
df = pd.DataFrame({
    "x": [1, 2, 2, 1, 3, 4, 4, 3],
    "y": [1, 1, 2, 2, 3, 3, 4, 4],
    "g": list("aaaabbbb"),
})

(
    ggplot(df, aes("x", "y", fill="g"))
    + geom_polygon(colour="black", size=1)
    + coord_trans(x="log10", y="log10")
)
```
Without this PR, a diagonal edge runs from the bottom-left corner of the first square to the second square.